### PR TITLE
Improve decorators classification

### DIFF
--- a/lib/decorators.js
+++ b/lib/decorators.js
@@ -39,22 +39,28 @@ class Registry extends Decorator {}
 class Dictionary extends Decorator {}
 class System extends Decorator {}
 class Log extends Decorator {}
+class View extends Decorator {}
 
 module.exports = {
-  // Field decorators
-  Enum: (...values) => new Enum(values),
-  Many: def => new Many(def),
-  Parent: def => new Parent(def),
-  Master: def => new Master(def),
-  Include: def => new Include(def),
-  // Index decorators
-  Index: (...values) => new Index(values),
-  Unique: (...fields) => new Unique(fields),
-  // Validation function decorator
-  Validate: fn => Object.setPrototypeOf(fn, Validate),
-  // Entity decorators
-  Registry: def => new Registry(def),
-  Dictionary: def => new Dictionary(def),
-  System: def => new System(def),
-  Log: def => new Log(def)
+  entity: {
+    // Entity decorators
+    Registry: def => new Registry(def),
+    Dictionary: def => new Dictionary(def),
+    System: def => new System(def),
+    Log: def => new Log(def),
+    View: def => new View(def)
+  },
+  attribute: {
+    // Field decorators
+    Enum: (...values) => new Enum(values),
+    Many: def => new Many(def),
+    Parent: def => new Parent(def),
+    Master: def => new Master(def),
+    Include: def => new Include(def),
+    // Index decorators
+    Index: (...fields) => new Index(fields),
+    Unique: (...fields) => new Unique(fields),
+    // Validation function decorator
+    Validate: fn => Object.setPrototypeOf(fn, Validate)
+  }
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -89,11 +89,15 @@ const createInstance = (
   return null;
 };
 
-Object.assign(structs, decorators, {
-  List: category => items => items.map(
-    item => createInstance(category, item)
-  )
-});
+decorators.attribute.List = category => items => items.map(
+  item => createInstance(category, item)
+);
+
+Object.assign(
+  structs,
+  decorators.entity,
+  decorators.attribute
+);
 
 const min = (a, b) => (a < b ? a : b);
 
@@ -257,6 +261,7 @@ module.exports = {
   build,
   domains,
   categories,
+  decorators,
   createInstance,
   validate,
   validateFields,


### PR DESCRIPTION
- Divide decorators into `decorators.entity` and `decorators.attribute`
- Add `View` entity decorator with example