### PR TITLE
Return and store sources of loaded schemas

### DIFF
--- a/lib/schema-fs-loader.js
+++ b/lib/schema-fs-loader.js
@@ -33,6 +33,7 @@ const processSchemaFile = (filename, decorators, source, api = {}) => {
 //     error - <Error> | <null>
 //     name - <string> schema name
 //     schema - <Object> parsed schema
+//     source - <string> schema source
 const loadSchema = (filepath, api, callback) => {
   fs.readFile(filepath, (err, source) => {
     if (err) {
@@ -47,7 +48,7 @@ const loadSchema = (filepath, api, callback) => {
       callback(e);
       return;
     }
-    callback(null, name, exports);
+    callback(null, name, exports, source);
   });
 };
 
@@ -55,12 +56,12 @@ const loadFiles = (files, api, callback) => {
   const schemas = [];
   files.unshift(domainsPath);
   metasync.each(files, (filepath, callback) => {
-    loadSchema(filepath, api, (err, name, schema) => {
+    loadSchema(filepath, api, (err, name, schema, source) => {
       if (err) {
         callback(err);
         return;
       }
-      schemas.push([name, schema]);
+      schemas.push([name, schema, source]);
       callback(null);
     });
   }, err => {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -102,11 +102,13 @@ class Metaschema {
     this.domains = new Map();
     this.categories = new Map();
     this.forms = new Map();
+    this.sources = [];
   }
 
   // Internal add schema, only processes the `schema`
   // but doesn't do anything else (i.e. linking)
-  [addSchema](name, schema) {
+  [addSchema](name, schema, source) {
+    this.sources.push(source);
     if (name === DOMAINS_NAME) {
       for (const name in schema) {
         const domain = schema[name];
@@ -270,12 +272,13 @@ class Metaschema {
 }
 
 // Creates Metaschema instance
-//   schemas - <Iterable> schemas in form [name, schema] (e.g. Map)
+//   schemas - <Iterable> schemas in form [name, schema, source]
+//             (the 'source' is optional)
 // Returns: <Metaschema>
 const create = schemas => {
   const ms = new Metaschema();
-  for (const [name, schema] of schemas) {
-    ms[addSchema](name, schema);
+  for (const [name, schema, source] of schemas) {
+    ms[addSchema](name, schema, source);
   }
   return [linkSchemas(schemas, ms.categories, ms.domains), ms];
 };


### PR DESCRIPTION
* return source as 3rd element of an array from `load`
* store schema sources as `Metaschema.sources`
* accept 'source' as 3rd element of elements in the argument to `create`