### PR TITLE
Improve error handling

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -57,7 +57,19 @@ ValidationError.serializers = {
   undefinedEntity: error => `Undefined ${error.info} '${error.property}'`,
 };
 
+class MetaschemaError extends Error {
+  constructor(errors) {
+    super();
+    this.errors = errors;
+  }
+
+  toString() {
+    return this.errors.map(e => e.toString()).join('\n');
+  }
+}
+
 module.exports = {
   SchemaValidationError,
   ValidationError,
+  MetaschemaError,
 };

--- a/lib/fs-loader.js
+++ b/lib/fs-loader.js
@@ -127,7 +127,7 @@ const loadModule = async (dir, options) => {
 //         If <Object> is provided it would be used as
 //         map from schema type (<string>) to order value (<number>),
 //         types with lower values are processed earlier.
-// Returns: [<Error[]>, <Metaschema>]
+// Returns: <Metaschema>
 const load = async (dir, options, config) => {
   if (!Array.isArray(dir)) {
     dir = [dir];

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { getProcessOrder } = require('./utils');
+const { MetaschemaError } = require('./errors');
 
 class Metaschema {
   constructor(config) {
@@ -29,7 +30,7 @@ class Metaschema {
   //       config.resolve
   //   instance <any>
   //   options <Object>
-  // Returns: <Error[]>
+  // Returns: <Error> | <null>
   validate(type, schema, instance, options) {
     if (typeof schema === 'string') {
       schema = this.config.resolve(this, type, schema);
@@ -38,7 +39,8 @@ class Metaschema {
     if (!validator) {
       throw new TypeError(`No validator defined for type: '${type}'`);
     }
-    return validator(this, schema, instance, options);
+    const errors = validator(this, schema, instance, options);
+    return errors.length === 0 ? null : new MetaschemaError(errors);
   }
 
   // Creates an instance of given schema
@@ -47,9 +49,7 @@ class Metaschema {
   //       config.resolve
   //   instance <any>
   //   options <Object>
-  // Returns:
-  //   <Error[]>
-  //   <any>
+  // Returns: <any>
   create(type, schema, args, options) {
     if (typeof schema === 'string') {
       schema = this.config.resolve(this, type, schema);
@@ -58,12 +58,13 @@ class Metaschema {
     if (!creator) {
       throw new TypeError(`No creator defined for type: '${type}'`);
     }
-    return creator(this, schema, args, options);
+    const [errors, result] = creator(this, schema, args, options);
+    if (errors.length !== 0) throw new MetaschemaError(errors);
+    return result;
   }
 
   // Adds multiple schemas
   //   schemas <Schema> | <Schema[]>
-  // Returns: <Error[]>
   addSchemas(schemas) {
     const errors = [];
     if (!Array.isArray(schemas)) schemas = [schemas];
@@ -89,9 +90,8 @@ class Metaschema {
       }
     }
 
-    if (errors.length) {
-      return errors;
-    }
+    if (errors.length !== 0) throw new MetaschemaError(errors);
+
     this.schemas.push(...schemas);
 
     for (const schema of schemas) {
@@ -104,7 +104,7 @@ class Metaschema {
       }
     }
 
-    return errors;
+    if (errors.length !== 0) throw new MetaschemaError(errors);
   }
 
   // Creates Metaschema object and fills it with schemas
@@ -158,13 +158,14 @@ class Metaschema {
   //         If <Object> is provided it would be used as
   //         map from schema type (<string>) to order value (<number>),
   //         types with lower values are processed earlier.
-  // Returns: [<Error[]>, <Metaschema>]
+  // Returns: <Metaschema>
   static create(schemas, config) {
     const ms = new Metaschema(config);
     if (config.prepare) {
       config.prepare(ms);
     }
-    return [ms.addSchemas(schemas), ms];
+    ms.addSchemas(schemas);
+    return ms;
   }
 }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -158,12 +158,16 @@ const validateCategory = (
 
     const opts = { ...options };
 
+    let err;
     if (definition.domain) {
       opts.path = `${path}${prop}`;
-      errors.push(...ms.validate('domains', definition.domain, value, opts));
+      err = ms.validate('domains', definition.domain, value, opts);
     } else if (definition.category) {
       opts.path = `${path}${prop}.`;
-      errors.push(...ms.validate('category', definition.category, value, opts));
+      err = ms.validate('category', definition.category, value, opts);
+    }
+    if (err) {
+      errors.push(...err.errors);
     }
 
     if (definition.validate && !definition.validate(value)) {

--- a/test/default.js
+++ b/test/default.js
@@ -47,18 +47,16 @@ const Person = {
 const categories = { FullName, Person };
 
 metatests.test('must properly process schemas', async test => {
-  let errors;
   let ms;
 
   try {
-    [errors, ms] = await load(path, options, config);
+    ms = await load(path, options, config);
   } catch (error) {
     test.fail(error);
     test.end();
     return;
   }
 
-  test.strictSame(errors.length, 0);
   test.strictSame(ms.domains.size, 3);
   test.strictSame(ms.categories.size, 2);
 

--- a/test/load.js
+++ b/test/load.js
@@ -51,18 +51,16 @@ const Person = {
 const categories = { FullName, Person };
 
 metatests.test('must properly load schemas', async test => {
-  let errors;
   let ms;
 
   try {
-    [errors, ms] = await load(path, options, config);
+    ms = await load(path, options, config);
   } catch (error) {
     test.fail(error);
     test.end();
     return;
   }
 
-  test.strictSame(errors.length, 0);
   test.strictSame(ms.domains.size, 3);
   test.strictSame(ms.categories.size, 2);
 

--- a/test/unresolved.js
+++ b/test/unresolved.js
@@ -2,7 +2,7 @@
 
 const metatests = require('metatests');
 
-const { SchemaValidationError } = require('../lib/errors');
+const { SchemaValidationError, MetaschemaError } = require('../lib/errors');
 
 const {
   fs: { load },
@@ -13,18 +13,15 @@ const { getSchemaDir } = require('./utils');
 const path = getSchemaDir('unresolved');
 
 metatests.test('must properly validate categories', async test => {
-  let errors;
-  let ms;
+  let error;
 
   try {
-    [errors, ms] = await load(path, options, config);
-  } catch (error) {
-    test.fail(error);
-    test.end();
-    return;
+    await load(path, options, config);
+  } catch (err) {
+    error = err;
   }
 
-  const expected = [
+  const expected = new MetaschemaError([
     new SchemaValidationError('unresolved', 'Person.DOB', {
       type: 'domain',
       value: 'DateTime',
@@ -33,12 +30,9 @@ metatests.test('must properly validate categories', async test => {
       type: 'category',
       value: 'FullName',
     }),
-  ];
+  ]);
 
-  test.strictSame(errors, expected);
-
-  test.strictSame(ms.domains.size, 0);
-  test.strictSame(ms.categories.size, 1);
+  test.strictSame(error, expected);
 
   test.end();
 });

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -14,18 +14,16 @@ const { getSchemaDir } = require('./utils');
 const path = getSchemaDir('utils');
 
 metatests.test('must properly load schemas', async test => {
-  let errors;
   let ms;
 
   try {
-    [errors, ms] = await load(path, options, config);
+    ms = await load(path, options, config);
   } catch (error) {
     test.fail(error);
     test.end();
     return;
   }
 
-  test.strictSame(errors, []);
   test.strictSame(ms.domains.size, 1);
   test.strictSame(ms.categories.size, 2);
 


### PR DESCRIPTION
Avoid returning the array of errors from the public methods and instead
return null or a single instance of Error that contains one or more
instances of Error in it. Also, reject a promise returned from
`metaschema.fs.load()` on errors during `Metaschema` object creation
instead of resolving it with an array of errors.