### PR TITLE
Long-from definition support

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -116,6 +116,25 @@ const formatLength = (length) => {
   return length;
 };
 
+const toLongForm = (type, def) => {
+  if (!type) return def;
+  if (type === 'enum') {
+    return Object.assign(def, { type, enum: def.enum });
+  } else if (type === 'array' || type === 'set') {
+    const value = def[type];
+    delete def[type];
+    return Object.assign(def, { type, value });
+  } else if (type === 'map' || type === 'object') {
+    const col = def[type];
+    delete def[type];
+    const key = Object.keys(col)[0];
+    const value = col[key];
+    return Object.assign(def, { type, key, value });
+  } else {
+    return { type };
+  }
+};
+
 class Schema {
   constructor(name, raw) {
     const short = shorthand(raw) || raw.type;
@@ -144,26 +163,14 @@ class Schema {
     for (const key of keys) {
       const entry = defs[key];
       const short = shorthand(entry);
-      const def = short ? { type: entry } : entry;
-      const type = short || def.type;
-      const { required } = entry;
-      if (type === 'enum') {
-        Object.assign(def, { type, enum: entry.enum, required });
-      } else if (type === 'array' || type === 'set') {
-        const value = entry[type];
-        delete def[type];
-        Object.assign(def, { type, value, required });
-      } else if (type === 'object' || type === 'map') {
-        const col = entry[type];
-        delete def[type];
-        const key = Object.keys(col)[0];
-        const value = col[key];
-        Object.assign(def, { type, key, value, required });
-      } else if (!type) {
-        if (this.preprocessIndex(key, def)) continue;
-        this.fields[key] = Schema.from(def);
+      const type = short || entry.type;
+
+      if (!type) {
+        if (this.preprocessIndex(key, entry)) continue;
+        this.fields[key] = Schema.from(entry);
         continue;
       }
+      const def = short ? toLongForm(type, { ...entry }) : entry;
       if (!Reflect.has(def, 'required')) def.required = true;
       if (def.length) def.length = formatLength(def.length);
       this.fields[key] = def;

--- a/test/schema.js
+++ b/test/schema.js
@@ -333,3 +333,56 @@ metatests.test('lib/schema check collections value', (test) => {
 
   test.end();
 });
+
+metatests.test(
+  'lib/schema check collections value if long form definition specified',
+  (test) => {
+    const def1 = { type: 'array', value: 'number' };
+    const obj1 = [1, 2, 3];
+    const schema1 = Schema.from(def1);
+    test.strictSame(schema1.check(obj1).valid, true);
+
+    const def2 = { type: 'array', value: 'number' };
+    const obj2 = ['uno', 2, 3];
+    const schema2 = Schema.from(def2);
+    test.strictSame(schema2.check(obj2).valid, false);
+
+    const def3 = { type: 'object', key: 'string', value: 'string' };
+    const obj3 = { a: 'A', b: 'B' };
+    const schema3 = Schema.from(def3);
+    test.strictSame(schema3.check(obj3).valid, true);
+
+    const def4 = { type: 'object', key: 'string', value: 'string' };
+    const obj4 = { a: 1, b: 'B' };
+    const schema4 = Schema.from(def4);
+    test.strictSame(schema4.check(obj4).valid, false);
+
+    const def5 = { type: 'set', value: 'number' };
+    const obj5 = new Set([1, 2, 3]);
+    const schema5 = Schema.from(def5);
+    test.strictSame(schema5.check(obj5).valid, true);
+
+    const def6 = { type: 'set', value: 'number' };
+    const obj6 = new Set(['uno', 2, 3]);
+    const schema6 = Schema.from(def6);
+    test.strictSame(schema6.check(obj6).valid, false);
+
+    const def7 = { type: 'map', key: 'string', value: 'string' };
+    const obj7 = new Map([
+      ['a', 'A'],
+      ['b', 'B'],
+    ]);
+    const schema7 = Schema.from(def7);
+    test.strictSame(schema7.check(obj7).valid, true);
+
+    const def8 = { type: 'map', key: 'string', value: 'string' };
+    const obj8 = new Set([
+      ['a', 1],
+      ['b', 'B'],
+    ]);
+    const schema8 = Schema.from(def8);
+    test.strictSame(schema8.check(obj8).valid, false);
+
+    test.end();
+  }
+);

--- a/test/schema.js
+++ b/test/schema.js
@@ -383,6 +383,12 @@ metatests.test(
     const schema8 = Schema.from(def8);
     test.strictSame(schema8.check(obj8).valid, false);
 
+    const def9 = { type: 'enum', enum: ['foo', 'bar'] };
+    const schema9 = Schema.from(def9);
+    test.strictSame(schema9.check('foo').valid, true);
+    test.strictSame(schema9.check('bar').valid, true);
+    test.strictSame(schema9.check('baz').valid, false);
+
     test.end();
   }
 );


### PR DESCRIPTION

I noticed that when I pass a [long form definition](https://github.com/metarhia/Contracts/blob/master/doc/Metaschema.md#collections) to the Schema constructor, the validation is broken.