### PR TITLE
Refactor tests: improve titles, formatting

### DIFF
--- a/test/database.js
+++ b/test/database.js
@@ -3,7 +3,7 @@
 const metatests = require('metatests');
 const { Schema } = require('..');
 
-metatests.test('lib/schema database', (test) => {
+metatests.test('Schema: database', (test) => {
   const raw = {
     Address: 'global registry',
 

--- a/test/loader.js
+++ b/test/loader.js
@@ -3,7 +3,7 @@
 const metatests = require('metatests');
 const { createSchema, loadSchema } = require('..');
 
-metatests.test('lib/schema create schema', (test) => {
+metatests.test('Schema: createSchema', (test) => {
   const definition = `({ field1: 'string' })`;
   const schema = createSchema('StructName', definition);
   test.strictSame(typeof schema.fields, 'object');
@@ -11,7 +11,7 @@ metatests.test('lib/schema create schema', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema load schema', async (test) => {
+metatests.test('Schema: loadSchema', async (test) => {
   const schema = await loadSchema('./test/examples/struct.js');
   test.strictSame(schema.fields.field1.type, 'string');
   test.strictSame(schema.fields.field2.type, 'number');

--- a/test/schema.js
+++ b/test/schema.js
@@ -3,7 +3,7 @@
 const metatests = require('metatests');
 const { Schema } = require('..');
 
-metatests.test('lib/schema constructor', (test) => {
+metatests.test('Schema: constructor', (test) => {
   const definition = { field1: 'string' };
   const schema = new Schema('StructName', definition);
   test.strictSame(schema.name, 'StructName');
@@ -19,7 +19,7 @@ metatests.test('lib/schema constructor', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema preprocess', (test) => {
+metatests.test('Schema: preprocess', (test) => {
   const definition = {
     field1: 'string',
     field2: { type: 'number' },
@@ -37,7 +37,7 @@ metatests.test('lib/schema preprocess', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema check', (test) => {
+metatests.test('Schema: check', (test) => {
   const definition = {
     field1: 'string',
     field2: { type: 'number' },
@@ -62,7 +62,7 @@ metatests.test('lib/schema check', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema shorthand', (test) => {
+metatests.test('Schema: shorthand', (test) => {
   const definition = {
     field1: {
       n: { type: 'number', default: 100 },
@@ -83,7 +83,7 @@ metatests.test('lib/schema shorthand', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema negative', (test) => {
+metatests.test('Schema: negative check', (test) => {
   const definition = {
     field1: 'string',
     field2: { type: 'number' },
@@ -127,7 +127,7 @@ metatests.test('lib/schema negative', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema check scalar', (test) => {
+metatests.test('Schema: check scalar', (test) => {
   const def1 = { type: 'string' };
   const schema1 = Schema.from(def1);
   test.strictSame(schema1.check('value').valid, true);
@@ -145,7 +145,7 @@ metatests.test('lib/schema check scalar', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema check enum', (test) => {
+metatests.test('Schema: check enum', (test) => {
   const definition = { field: { enum: ['uno', 'due', 'tre'] } };
   const schema = Schema.from(definition);
   test.strictSame(schema.check({ field: 'uno' }).valid, true);
@@ -182,7 +182,7 @@ metatests.test('lib/schema check enum', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema check enum value', (test) => {
+metatests.test('Schema: check enum value', (test) => {
   const def1 = { enum: ['uno', 'due', 'tre'] };
   const schema1 = Schema.from(def1);
   test.strictSame(schema1.check('uno').valid, true);
@@ -202,7 +202,7 @@ metatests.test('lib/schema check enum value', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema check collections', (test) => {
+metatests.test('Schema: check collections', (test) => {
   const def1 = {
     field1: { array: 'number' },
   };
@@ -284,7 +284,7 @@ metatests.test('lib/schema check collections', (test) => {
   test.end();
 });
 
-metatests.test('lib/schema check collections value', (test) => {
+metatests.test('Schema: check collections value', (test) => {
   const def1 = { array: 'number' };
   const obj1 = [1, 2, 3];
   const schema1 = Schema.from(def1);
@@ -334,66 +334,63 @@ metatests.test('lib/schema check collections value', (test) => {
   test.end();
 });
 
-metatests.test(
-  'lib/schema check collections value if long form definition specified',
-  (test) => {
-    const def1 = { type: 'array', value: 'number' };
-    const obj1 = [1, 2, 3];
-    const schema1 = Schema.from(def1);
-    test.strictSame(schema1.check(obj1).valid, true);
+metatests.test('Schema: check collections value with long form', (test) => {
+  const def1 = { type: 'array', value: 'number' };
+  const obj1 = [1, 2, 3];
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check(obj1).valid, true);
 
-    const def2 = { type: 'array', value: 'number' };
-    const obj2 = ['uno', 2, 3];
-    const schema2 = Schema.from(def2);
-    test.strictSame(schema2.check(obj2).valid, false);
+  const def2 = { type: 'array', value: 'number' };
+  const obj2 = ['uno', 2, 3];
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check(obj2).valid, false);
 
-    const def3 = { type: 'object', key: 'string', value: 'string' };
-    const obj3 = { a: 'A', b: 'B' };
-    const schema3 = Schema.from(def3);
-    test.strictSame(schema3.check(obj3).valid, true);
+  const def3 = { type: 'object', key: 'string', value: 'string' };
+  const obj3 = { a: 'A', b: 'B' };
+  const schema3 = Schema.from(def3);
+  test.strictSame(schema3.check(obj3).valid, true);
 
-    const def4 = { type: 'object', key: 'string', value: 'string' };
-    const obj4 = { a: 1, b: 'B' };
-    const schema4 = Schema.from(def4);
-    test.strictSame(schema4.check(obj4).valid, false);
+  const def4 = { type: 'object', key: 'string', value: 'string' };
+  const obj4 = { a: 1, b: 'B' };
+  const schema4 = Schema.from(def4);
+  test.strictSame(schema4.check(obj4).valid, false);
 
-    const def5 = { type: 'set', value: 'number' };
-    const obj5 = new Set([1, 2, 3]);
-    const schema5 = Schema.from(def5);
-    test.strictSame(schema5.check(obj5).valid, true);
+  const def5 = { type: 'set', value: 'number' };
+  const obj5 = new Set([1, 2, 3]);
+  const schema5 = Schema.from(def5);
+  test.strictSame(schema5.check(obj5).valid, true);
 
-    const def6 = { type: 'set', value: 'number' };
-    const obj6 = new Set(['uno', 2, 3]);
-    const schema6 = Schema.from(def6);
-    test.strictSame(schema6.check(obj6).valid, false);
+  const def6 = { type: 'set', value: 'number' };
+  const obj6 = new Set(['uno', 2, 3]);
+  const schema6 = Schema.from(def6);
+  test.strictSame(schema6.check(obj6).valid, false);
 
-    const def7 = { type: 'map', key: 'string', value: 'string' };
-    const obj7 = new Map([
-      ['a', 'A'],
-      ['b', 'B'],
-    ]);
-    const schema7 = Schema.from(def7);
-    test.strictSame(schema7.check(obj7).valid, true);
+  const def7 = { type: 'map', key: 'string', value: 'string' };
+  const obj7 = new Map([
+    ['a', 'A'],
+    ['b', 'B'],
+  ]);
+  const schema7 = Schema.from(def7);
+  test.strictSame(schema7.check(obj7).valid, true);
 
-    const def8 = { type: 'map', key: 'string', value: 'string' };
-    const obj8 = new Set([
-      ['a', 1],
-      ['b', 'B'],
-    ]);
-    const schema8 = Schema.from(def8);
-    test.strictSame(schema8.check(obj8).valid, false);
+  const def8 = { type: 'map', key: 'string', value: 'string' };
+  const obj8 = new Set([
+    ['a', 1],
+    ['b', 'B'],
+  ]);
+  const schema8 = Schema.from(def8);
+  test.strictSame(schema8.check(obj8).valid, false);
 
-    const def9 = { type: 'enum', enum: ['foo', 'bar'] };
-    const schema9 = Schema.from(def9);
-    test.strictSame(schema9.check('foo').valid, true);
-    test.strictSame(schema9.check('bar').valid, true);
-    test.strictSame(schema9.check('baz').valid, false);
+  const def9 = { type: 'enum', enum: ['foo', 'bar'] };
+  const schema9 = Schema.from(def9);
+  test.strictSame(schema9.check('foo').valid, true);
+  test.strictSame(schema9.check('bar').valid, true);
+  test.strictSame(schema9.check('baz').valid, false);
 
-    test.end();
-  }
-);
+  test.end();
+});
 
-metatests.test('Schema to interface', (test) => {
+metatests.test('Schema: generate ts interface', (test) => {
   const raw = {
     Company: 'global dictionary',
     name: { type: 'string', unique: true },


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
