### PR TITLE
Shorthand for optional (not required) fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Shorthand for optional (not required) fields
+
 ## [1.1.1][] - 2021-05-07
 
 - Support nested schemas for Model class

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -165,15 +165,19 @@ class Schema {
     for (const key of keys) {
       const entry = defs[key];
       const short = shorthand(entry);
-      const type = short || entry.type;
-
+      let type = short || entry.type;
       if (!type) {
         if (this.preprocessIndex(key, entry)) continue;
         this.fields[key] = Schema.from(entry);
         continue;
       }
+      let required = true;
+      if (type.startsWith('?')) {
+        type = type.substring(1);
+        required = false;
+      }
       const def = short ? toLongForm(type, { ...entry }) : entry;
-      if (!Reflect.has(def, 'required')) def.required = true;
+      if (!Reflect.has(def, 'required')) def.required = required;
       if (def.length) def.length = formatLength(def.length);
       this.fields[key] = def;
     }

--- a/test/schema.js
+++ b/test/schema.js
@@ -83,6 +83,22 @@ metatests.test('Schema: shorthand', (test) => {
   test.end();
 });
 
+metatests.test('Schema: required shorthand', (test) => {
+  const definition = { name: '?string' };
+  const schema = Schema.from(definition);
+
+  const obj1 = { name: 'value' };
+  test.strictSame(schema.check(obj1).valid, true);
+
+  const obj2 = {};
+  test.strictSame(schema.check(obj2).valid, true);
+
+  const obj3 = { name: 100 };
+  test.strictSame(schema.check(obj3).valid, false);
+
+  test.end();
+});
+
 metatests.test('Schema: negative check', (test) => {
   const definition = {
     field1: 'string',


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
