### PR TITLE
Restrict 'type' property in db schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Add warning for top level 'type' property on an entity
+
 ## [1.2.2][] - 2021-05-17
 
 - Fix unique alternative keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## [Unreleased][unreleased]
 
-- Add warning for top level 'type' property on an entity
-- Add 'Model.warnings' typings
+- Restrict 'type' property in db schemas
 
 ## [1.2.2][] - 2021-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Add warning for top level 'type' property on an entity
+- Add 'Model.warnings' typings
 
 ## [1.2.2][] - 2021-05-17
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -18,8 +18,13 @@ class Model {
     this.entities = new Map();
     this.database = database;
     this.order = new Set();
-    this.warnings = checkEntities(entities);
+    this.warnings = [];
     for (const [name, entity] of entities) {
+      if (entity.type) {
+        this.warnings.push(
+          `Warning: 'type' property is restricted in database schemas: ${name}`
+        );
+      }
       const schema = new Schema(name, entity);
       this.entities.set(name, schema);
     }
@@ -92,19 +97,6 @@ class Model {
     }
     await fsp.writeFile(outputFile, dts.join('\n\n') + '\n');
   }
-}
-
-function checkEntities(entities) {
-  return [...entities]
-    .filter(([, entity]) =>
-      Object.prototype.hasOwnProperty.call(entity, 'type')
-    )
-    .map(
-      ([name]) =>
-        `Warning: top level 'type' property on a '${name}'.\n` +
-        'This will result in it being treated as a scalar type.\n' +
-        'Rename property or move the entity to dedicated types file.'
-    );
 }
 
 module.exports = { Model };

--- a/lib/model.js
+++ b/lib/model.js
@@ -18,7 +18,7 @@ class Model {
     this.entities = new Map();
     this.database = database;
     this.order = new Set();
-    this.warnings = [];
+    this.warnings = checkEntities(entities);
     for (const [name, entity] of entities) {
       const schema = new Schema(name, entity);
       this.entities.set(name, schema);
@@ -92,6 +92,19 @@ class Model {
     }
     await fsp.writeFile(outputFile, dts.join('\n\n') + '\n');
   }
+}
+
+function checkEntities(entities) {
+  return [...entities]
+    .filter(([, entity]) =>
+      Object.prototype.hasOwnProperty.call(entity, 'type')
+    )
+    .map(
+      ([name]) =>
+        `Warning: top level 'type' property on a '${name}'.\n` +
+        'This will result in it being treated as a scalar type.\n' +
+        'Rename property or move the entity to dedicated types file.'
+    );
 }
 
 module.exports = { Model };

--- a/test/model.js
+++ b/test/model.js
@@ -77,18 +77,11 @@ metatests.test('Model: loader', async (test) => {
   test.end();
 });
 
-metatests.test(
-  `Model: top level 'type' property on an entity warning`,
-  (test) => {
-    const model = new Model(
-      { string: 'string' },
-      new Map([['FailingEntity', { type: 'string' }]])
-    );
-    test.strictEqual(model.warnings, [
-      `Warning: top level 'type' property on a 'FailingEntity'.\n` +
-        'This will result in it being treated as a scalar type.\n' +
-        'Rename property or move the entity to dedicated types file.',
-    ]);
-    test.end();
-  }
-);
+metatests.test(`Model: restricted 'type' property in db schemas`, (test) => {
+  const model = new Model(
+    { string: 'string' },
+    new Map([['FailingEntity', { type: 'string' }]])
+  );
+  test.strictEqual(model.warnings.length, 1);
+  test.end();
+});

--- a/test/model.js
+++ b/test/model.js
@@ -76,3 +76,19 @@ metatests.test('Model: loader', async (test) => {
   test.strictEqual(typeof model.database, 'object');
   test.end();
 });
+
+metatests.test(
+  `Model: top level 'type' property on an entity warning`,
+  (test) => {
+    const model = new Model(
+      { string: 'string' },
+      new Map([['FailingEntity', { type: 'string' }]])
+    );
+    test.strictEqual(model.warnings, [
+      `Warning: top level 'type' property on a 'FailingEntity'.\n` +
+        'This will result in it being treated as a scalar type.\n' +
+        'Rename property or move the entity to dedicated types file.',
+    ]);
+    test.end();
+  }
+);

--- a/types/metaschema.d.ts
+++ b/types/metaschema.d.ts
@@ -40,7 +40,7 @@ export class Model {
   entities: Map<string, object>;
   database: object;
   order: Set<string>;
-  warnings: string[];
+  warnings: Array<string>;
   constructor(types: object, entities: Map<string, object>, database?: object);
   static load(modelPath: string, systemTypes?: object): Promise<Model>;
   preprocess(): void;

--- a/types/metaschema.d.ts
+++ b/types/metaschema.d.ts
@@ -40,6 +40,7 @@ export class Model {
   entities: Map<string, object>;
   database: object;
   order: Set<string>;
+  warnings: string[];
   constructor(types: object, entities: Map<string, object>, database?: object);
   static load(modelPath: string, systemTypes?: object): Promise<Model>;
   preprocess(): void;


### PR DESCRIPTION
Closes: https://github.com/metarhia/metaschema/issues/324

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
- [x] update .d.ts typings
