### PR TITLE
Refactoring, optimizations

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -177,11 +177,8 @@ class Schema {
         }
         continue;
       }
-      let required = true;
-      if (type.startsWith('?')) {
-        type = type.substring(1);
-        required = false;
-      }
+      const required = !type.startsWith('?');
+      if (!required) type = type.substring(1);
       const def = short ? toLongForm(type, { ...entry }) : entry;
       if (!Reflect.has(def, 'required')) def.required = required;
       if (def.length) def.length = formatLength(def.length);
@@ -210,8 +207,8 @@ class Schema {
 
   checkConsistency() {
     const warn = [];
-    const { name } = this;
-    for (const ref of this.references) {
+    const { name, references } = this;
+    for (const ref of references) {
       if (isFirstUpper(ref)) {
         if (!this.findReference(ref)) {
           warn.push(`Warning: "${ref}" referenced by "${name}" is not found`);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
