### PR TITLE
Show path to the field in warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Show path to the field in warnings
+
 ## [1.3.3][] - 2021-07-19
 
 - Improve code style

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -238,7 +238,7 @@ class Schema {
     return null;
   }
 
-  check(value) {
+  check(value, path = '') {
     const target = this.kind === 'scalar' ? { value } : value || {};
     const keys = Object.keys(target);
     const fields = Object.keys(this.fields);
@@ -257,21 +257,21 @@ class Schema {
         def = this.findReference(def.type);
       }
       if (!def) {
-        errors.push(`Field "${name}" is not expected`);
+        errors.push(`Field "${path}${name}" is not expected`);
         continue;
       }
       if (def instanceof Schema) {
-        const subcheck = def.check(value);
+        const subcheck = def.check(value, name + '.');
         if (!subcheck.valid) errors.push(...subcheck.errors);
         continue;
       }
       if (def.json instanceof Schema) {
-        const subcheck = def.json.check(value);
+        const subcheck = def.json.check(value, name + '.');
         if (!subcheck.valid) errors.push(...subcheck.errors);
         continue;
       }
       if (def.required && !keys.includes(name)) {
-        errors.push(`Field "${name}" is required`);
+        errors.push(`Field "${path}${name}" is required`);
         continue;
       }
       const errs = check(name, def, value);

--- a/test/schema.js
+++ b/test/schema.js
@@ -104,13 +104,17 @@ metatests.test('Schema: nested json, lost field', (test) => {
     field2: {
       subfield1: 'number',
     },
+    field3: 'string',
   };
   const obj = {
     field1: 'value',
   };
   const schema = Schema.from(definition);
   test.strictSame(schema.check(obj).valid, false);
-  test.strictSame(schema.check(obj).errors, ['Field "subfield1" is required']);
+  test.strictSame(schema.check(obj).errors, [
+    'Field "field2.subfield1" is required',
+    'Field "field3" is required',
+  ]);
   test.end();
 });
 


### PR DESCRIPTION
Closes: https://github.com/metarhia/impress/issues/1614

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
