### PR TITLE
Rewrite schemas and implement custom types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "arrow-parens": ["error", "always"],
     "comma-dangle": "off",
     "handle-callback-err": "off",
-    "consistent-return": "off"
+    "consistent-return": "off",
+    "new-cap": "off"
   }
 }

--- a/lib/kinds.js
+++ b/lib/kinds.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const KIND_ENT = ['entity', 'registry', 'dictionary'];
+const KIND_AUX = ['journal', 'details', 'relation', 'view'];
+const KIND_STORED = [...KIND_ENT, ...KIND_AUX];
+const KIND_MEMORY = ['struct', 'scalar', 'form', 'projection'];
+
+const SCOPE = ['application', 'global', 'local'];
+const STORE = ['persistent', 'memory'];
+const ALLOW = ['write', 'append', 'read'];
+
+const projection = (meta = {}, root) => {
+  const metadata = {
+    scope: meta.scope || 'local',
+    store: meta.store || 'memory',
+    allow: meta.allow || 'write',
+  };
+  const { schema, fields } = meta;
+  if (!schema && !fields) throw new Error('Invalid Projection');
+  metadata.parent = schema;
+  const parent = root.findReference(schema);
+  const defs = {};
+  for (const key of fields) {
+    defs[key] = parent.fields[key];
+  }
+  return { defs, metadata };
+};
+
+const kindStored = (meta = {}) => ({
+  metadata: {
+    scope: meta.scope || 'application',
+    store: meta.store || 'persistent',
+    allow: meta.allow || 'write',
+  },
+});
+
+const kindMemory = (meta = {}) => ({
+  metadata: {
+    scope: meta.scope || 'local',
+    store: meta.store || 'memory',
+    allow: meta.allow || 'write',
+  },
+});
+
+const KIND = {
+  registry: kindStored,
+  entity: kindStored,
+  dictionary: kindStored,
+  relation: kindStored,
+  journal: kindStored,
+  details: kindStored,
+  view: kindStored,
+
+  struct: kindMemory,
+  scalar: kindMemory,
+  form: kindMemory,
+  projection,
+};
+
+module.exports = { KIND, KIND_STORED, KIND_MEMORY, SCOPE, STORE, ALLOW };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,6 +6,7 @@ const path = require('path');
 const metavm = require('metavm');
 
 const { Schema } = require('./schema.js');
+const { Model } = require('./model.js');
 
 const createSchema = (name, src) => {
   const { exports } = new metavm.MetaScript(name, src);
@@ -34,4 +35,22 @@ const readDirectory = async (dirPath) => {
   return structs;
 };
 
-module.exports = { createSchema, loadSchema, readDirectory };
+const loadModel = async (modelPath, systemTypes = {}) => {
+  const structs = await readDirectory(modelPath);
+  const database = structs.get('.database') || null;
+  const customTypes = structs.get('.types') || {};
+  structs.delete('.database');
+  structs.delete('.types');
+  const types = { ...systemTypes, ...customTypes };
+  return new Model(types, structs, database);
+};
+
+const saveTypes = (outputFile, model) => fsp.writeFile(outputFile, model.dts);
+
+module.exports = {
+  createSchema,
+  loadSchema,
+  readDirectory,
+  loadModel,
+  saveTypes,
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -9,11 +9,22 @@ class Model {
     this.entities = new Map();
     this.database = database;
     this.order = new Set();
+    this.last = new Set();
     this.warnings = [];
     for (const [name, entity] of entities) {
+      const first = Object.keys(entity)[0];
+      if (first === 'Projection') {
+        this.last.add([name, entity]);
+        continue;
+      }
       const schema = new Schema(name, entity, [this]);
       this.entities.set(name, schema);
     }
+    for (const [name, entity] of this.last) {
+      const schema = new Schema(name, entity, [this]);
+      this.entities.set(name, schema);
+    }
+    this.last.clear();
     this.preprocess();
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -25,7 +25,6 @@ class Model {
       const schema = new Schema(name, entity, [this]);
       this.entities.set(name, schema);
     }
-    last.clear();
     this.preprocess();
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2,6 +2,7 @@
 
 const { Schema } = require('./schema.js');
 const { prepareTypes } = require('./types.js');
+const { firstKey } = require('./util.js');
 
 class Model {
   constructor(types, entities, database = null) {
@@ -12,7 +13,7 @@ class Model {
     this.warnings = [];
     const last = new Set();
     for (const [name, entity] of entities) {
-      const first = Object.keys(entity)[0];
+      const first = firstKey(entity);
       if (first === 'Projection') {
         last.add([name, entity]);
         continue;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,37 +1,20 @@
 'use strict';
 
-const fsp = require('fs').promises;
 const { Schema } = require('./schema.js');
-const { readDirectory } = require('./loader.js');
-const { TYPES } = require('./types.js');
+const { prepareTypes } = require('./types.js');
 
 class Model {
   constructor(types, entities, database = null) {
-    this.types = types;
+    this.types = prepareTypes(types);
     this.entities = new Map();
     this.database = database;
     this.order = new Set();
     this.warnings = [];
     for (const [name, entity] of entities) {
-      if (entity.type) {
-        this.warnings.push(
-          `Warning: 'type' property is restricted in database schemas: ${name}`
-        );
-      }
       const schema = new Schema(name, entity, [this]);
       this.entities.set(name, schema);
     }
     this.preprocess();
-  }
-
-  static async load(modelPath, systemTypes = {}) {
-    const structs = await readDirectory(modelPath);
-    const database = structs.get('.database') || null;
-    const customTypes = structs.get('.types') || {};
-    structs.delete('.database');
-    structs.delete('.types');
-    const types = { ...TYPES, ...systemTypes, ...customTypes };
-    return new Model(types, structs, database);
   }
 
   preprocess() {
@@ -52,7 +35,8 @@ class Model {
   reorderEntity(name, base) {
     const entity = this.entities.get(name);
     if (!entity) return;
-    for (const ref of entity.references) {
+    const { references } = entity;
+    for (const ref of references) {
       if (ref === name) continue;
       if (ref === base) {
         this.warnings.push(`Recursive dependency: ${name}.${base}`);
@@ -63,14 +47,14 @@ class Model {
     this.order.add(name);
   }
 
-  async saveTypes(outputFile) {
+  get dts() {
     const { entities, order } = this;
     const dts = [];
     for (const name of order) {
       const schema = entities.get(name);
       dts.push(schema.toInterface(name));
     }
-    await fsp.writeFile(outputFile, dts.join('\n\n') + '\n');
+    return dts.join('\n\n') + '\n';
   }
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -46,8 +46,7 @@ class Model {
   reorderEntity(name, base) {
     const entity = this.entities.get(name);
     if (!entity) return;
-    const { references } = entity;
-    for (const ref of references) {
+    for (const ref of entity.references) {
       if (ref === name) continue;
       if (ref === base) {
         this.warnings.push(`Recursive dependency: ${name}.${base}`);

--- a/lib/model.js
+++ b/lib/model.js
@@ -9,22 +9,22 @@ class Model {
     this.entities = new Map();
     this.database = database;
     this.order = new Set();
-    this.last = new Set();
     this.warnings = [];
+    const last = new Set();
     for (const [name, entity] of entities) {
       const first = Object.keys(entity)[0];
       if (first === 'Projection') {
-        this.last.add([name, entity]);
+        last.add([name, entity]);
         continue;
       }
       const schema = new Schema(name, entity, [this]);
       this.entities.set(name, schema);
     }
-    for (const [name, entity] of this.last) {
+    for (const [name, entity] of last) {
       const schema = new Schema(name, entity, [this]);
       this.entities.set(name, schema);
     }
-    this.last.clear();
+    last.clear();
     this.preprocess();
   }
 

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { isFirstUpper, toLowerCamel } = require('metautil');
+const { formatters, firstKey, omit } = require('./util.js');
+
+class Preprocessor {
+  constructor(types, Schema) {
+    this.Schema = Schema;
+    this.types = types;
+  }
+
+  parse(source) {
+    const srcType = Array.isArray(source) ? 'tuple' : typeof source;
+    return this.recognize(srcType, source);
+  }
+
+  single(def) {
+    const { types } = this;
+    const [type, required] = formatters.type(
+      def.type || def,
+      def.required || true
+    );
+    if (isFirstUpper(type)) {
+      return new types.reference({ one: type, required, ...def });
+    }
+    if (!types[type]) throw new Error(`Unknown type ${type}`);
+    return new types[type]({ required, ...def }, this);
+  }
+
+  recognize(srcType, source) {
+    const { types } = this;
+    if (srcType === 'string') {
+      return this.single(source);
+    }
+    if (srcType === 'object') {
+      const first = firstKey(source);
+      // schema with kind
+      if (isFirstUpper(first)) {
+        const [metadata, defs] = omit(first, source);
+        metadata.kind = toLowerCamel(first);
+        return { defs, metadata };
+      }
+      // longform definition
+      if (source.type) return this.single(source);
+      // shorthand
+      const [type, required] = formatters.key(first, source.required);
+      if (types[type]) {
+        const [def, rest] = omit(first, source);
+        return new types[type]({ [type]: def, required, ...rest }, this);
+      }
+      // schema
+      return { defs: source };
+    }
+    if (srcType === 'function') return { skip: source };
+    throw new Error(`Invalid definition: "${source}" of type ${srcType}`);
+  }
+}
+
+module.exports = { Preprocessor };

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -4,9 +4,11 @@ const { isFirstUpper, toLowerCamel } = require('metautil');
 const { formatters, firstKey, omit } = require('./util.js');
 
 class Preprocessor {
-  constructor(types, Schema) {
+  constructor(root, Schema) {
     this.Schema = Schema;
-    this.types = types;
+    this.root = root;
+    this.kinds = Schema.KIND;
+    this.types = root.getTypes();
   }
 
   parse(source) {
@@ -16,10 +18,7 @@ class Preprocessor {
 
   single(def) {
     const { types } = this;
-    const [type, required] = formatters.type(
-      def.type || def,
-      def.required || true
-    );
+    const [type, required] = formatters.type(def.type, def.required);
     if (isFirstUpper(type)) {
       return new types.reference({ one: type, required, ...def });
     }
@@ -29,27 +28,33 @@ class Preprocessor {
 
   recognize(srcType, source) {
     const { types } = this;
+    // scalar or refernce shorthand
     if (srcType === 'string') {
-      return this.single(source);
+      return this.single({ type: source });
     }
     if (srcType === 'object') {
       const first = firstKey(source);
       // schema with kind
       if (isFirstUpper(first)) {
-        const [metadata, defs] = omit(first, source);
-        metadata.kind = toLowerCamel(first);
-        return { defs, metadata };
+        const { kinds, root } = this;
+        const [meta, fields] = omit(first, source);
+        const kind = toLowerCamel(first);
+        const { defs, metadata } = kinds[kind](meta, root);
+        return { defs: defs || fields, metadata: { ...metadata, kind } };
       }
       // longform definition
       if (source.type) return this.single(source);
-      // shorthand
+      // complex type or any custom type shorthand
       const [type, required] = formatters.key(first, source.required);
       if (types[type]) {
         const [def, rest] = omit(first, source);
         return new types[type]({ [type]: def, required, ...rest }, this);
       }
       // schema
-      return { defs: source };
+      return {
+        defs: source,
+        metadata: { ...this.kinds.struct(), kind: 'struct' },
+      };
     }
     if (srcType === 'function') return { skip: source };
     throw new Error(`Invalid definition: "${source}" of type ${srcType}`);

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { isFirstUpper, toLowerCamel } = require('metautil');
-const { formatters, firstKey, omit } = require('./util.js');
+const { formatters, firstKey } = require('./util.js');
 
 class Preprocessor {
   constructor(root, Schema) {
@@ -37,7 +37,7 @@ class Preprocessor {
       // schema with kind
       if (isFirstUpper(first)) {
         const { kinds, root } = this;
-        const [meta, fields] = omit(first, source);
+        const { [first]: meta, ...fields } = source;
         const kind = toLowerCamel(first);
         const { defs, metadata } = kinds[kind](meta, root);
         return { defs: defs || fields, metadata: { ...metadata, kind } };
@@ -47,7 +47,7 @@ class Preprocessor {
       // complex type or any custom type shorthand
       const [type, required] = formatters.key(first, source.required);
       if (types[type]) {
-        const [def, rest] = omit(first, source);
+        const { [first]: def, ...rest } = source;
         return new types[type]({ [type]: def, required, ...rest }, this);
       }
       // schema
@@ -56,7 +56,7 @@ class Preprocessor {
         metadata: { ...this.kinds.struct(), kind: 'struct' },
       };
     }
-    if (srcType === 'function') return { skip: source };
+    if (srcType === 'function') return { skip: true };
     throw new Error(`Invalid definition: "${source}" of type ${srcType}`);
   }
 }

--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -1,46 +1,42 @@
 'use strict';
 
-const { formatters, checks, harmonize } = require('../util.js');
+const { harmonize } = require('../util.js');
 
 const AbstractType = {
   formatters: {},
-  checks: {},
+  checks: [],
   check(value, path, root) {
+    const field = path || root.name;
     try {
-      const typeErr = harmonize(this.checkType(value, path, root));
+      const typeErr = harmonize(this.checkType(value, path, root), field);
       if (typeErr) return typeErr;
       if (this.validate) {
-        const validErr = harmonize(this.validate(value, path, root));
+        const validErr = harmonize(this.validate(value, path, root), field);
         if (validErr) return validErr;
       }
-      for (const [name, subCheck] of Object.entries(this.checks)) {
-        if (this[name]) subCheck(value, path, this);
+      for (const subCheck of this.checks) {
+        const err = harmonize(subCheck(value, this), field);
+        if (err) return err;
       }
       return [];
     } catch (err) {
-      return [err.message];
+      return harmonize(`validation failed ${String(err)}`, field);
     }
   },
-  metadataFrom(type) {
-    const { references, relations } = this;
-    this.references = new Set([...references, ...type.references]);
-    this.relations = new Set([...relations, ...type.relations]);
+  updateMetadata(type) {
+    type.references.forEach(this.references.add, this.references);
+    type.relations.forEach(this.relations.add, this.relations);
   },
   init() {
     this.references = new Set();
     this.relations = new Set();
-    const rules = this.rules || [];
-    for (const rule of rules) {
-      if (formatters[rule]) this.formatters[rule] = formatters[rule];
-      if (checks[rule]) this.checks[rule] = checks[rule];
-    }
   },
   from(def = {}, preprocessor) {
     const { formatters } = this;
-    for (const key of Object.keys(def)) {
+    for (const [key, value] of Object.entries(def)) {
       if (key === 'type' || key === this.type) continue;
-      if (formatters[key]) this[key] = formatters[key](def[key]);
-      else this[key] = def[key];
+      if (formatters[key]) this[key] = formatters[key](value);
+      else this[key] = value;
     }
     this.construct(def, preprocessor);
     const { type } = this;

--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -1,15 +1,18 @@
 'use strict';
 
-const { formatters, checks } = require('../util.js');
+const { formatters, checks, harmonize } = require('../util.js');
 
 const AbstractType = {
   formatters: {},
   checks: {},
   check(value, path, root) {
     try {
-      const res = this.validate(value, path, root);
-      const err = typeof res === 'boolean' ? !res : res;
-      if (err) return Array.isArray(err) ? err : [err];
+      const typeErr = harmonize(this.checkType(value, path, root));
+      if (typeErr) return typeErr;
+      if (this.validate) {
+        const validErr = harmonize(this.validate(value, path, root));
+        if (validErr) return validErr;
+      }
       for (const [name, subCheck] of Object.entries(this.checks)) {
         if (this[name]) subCheck(value, path, this);
       }
@@ -39,7 +42,7 @@ const AbstractType = {
       if (formatters[key]) this[key] = formatters[key](def[key]);
       else this[key] = def[key];
     }
-    this.format(def, preprocessor);
+    this.construct(def, preprocessor);
     const { type } = this;
     this.type = type;
     this.references.add(type);

--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { harmonize } = require('../util.js');
+const { prettifyErr } = require('../util.js');
 
 const AbstractType = {
   formatters: {},
@@ -8,20 +8,20 @@ const AbstractType = {
   check(value, path, root) {
     const field = path || root.name;
     try {
-      const typeErr = harmonize(this.checkType(value, path, root), field);
+      const typeErr = prettifyErr(this.checkType(value, path, root), field);
       if (typeErr) return typeErr;
       if (this.validate) {
-        const validErr = harmonize(this.validate(value, path, root), field);
+        const validErr = prettifyErr(this.validate(value, path, root), field);
         if (validErr) return validErr;
       }
       for (const [name, subCheck] of Object.entries(this.checks)) {
         if (!this[name]) continue;
-        const err = harmonize(subCheck(value, this), field);
+        const err = prettifyErr(subCheck(value, this), field);
         if (err) return err;
       }
       return [];
     } catch (err) {
-      return harmonize(`validation failed ${String(err)}`, field);
+      return prettifyErr(`validation failed ${String(err)}`, field);
     }
   },
   updateMetadata(type) {

--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -4,7 +4,7 @@ const { harmonize } = require('../util.js');
 
 const AbstractType = {
   formatters: {},
-  checks: [],
+  checks: {},
   check(value, path, root) {
     const field = path || root.name;
     try {

--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { formatters, checks } = require('../util.js');
+
+const AbstractType = {
+  formatters: {},
+  checks: {},
+  check(value, path, root) {
+    try {
+      const res = this.validate(value, path, root);
+      const err = typeof res === 'boolean' ? !res : res;
+      if (err) return Array.isArray(err) ? err : [err];
+      for (const [name, subCheck] of Object.entries(this.checks)) {
+        if (this[name]) subCheck(value, path, this);
+      }
+      return [];
+    } catch (err) {
+      return [err.message];
+    }
+  },
+  metadataFrom(type) {
+    const { references, relations } = this;
+    this.references = new Set([...references, ...type.references]);
+    this.relations = new Set([...relations, ...type.relations]);
+  },
+  init() {
+    this.references = new Set();
+    this.relations = new Set();
+    const rules = this.rules || [];
+    for (const rule of rules) {
+      if (formatters[rule]) this.formatters[rule] = formatters[rule];
+      if (checks[rule]) this.checks[rule] = checks[rule];
+    }
+  },
+  from(def = {}, preprocessor) {
+    const { formatters } = this;
+    for (const key of Object.keys(def)) {
+      if (key === 'type' || key === this.type) continue;
+      if (formatters[key]) this[key] = formatters[key](def[key]);
+      else this[key] = def[key];
+    }
+    this.format(def, preprocessor);
+    const { type } = this;
+    this.type = type;
+    this.references.add(type);
+  },
+};
+
+module.exports = { AbstractType };

--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -14,7 +14,8 @@ const AbstractType = {
         const validErr = harmonize(this.validate(value, path, root), field);
         if (validErr) return validErr;
       }
-      for (const subCheck of this.checks) {
+      for (const [name, subCheck] of Object.entries(this.checks)) {
+        if (!this[name]) continue;
         const err = harmonize(subCheck(value, this), field);
         if (err) return err;
       }

--- a/lib/prototypes/collections.js
+++ b/lib/prototypes/collections.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { isType } = require('../util.js');
+
+const object = {
+  rules: ['length'],
+  type: 'object',
+  kind: 'struct',
+  validate(source, path) {
+    const { type, key, value } = this;
+    if (!this.isInstance(source)) {
+      return `Filed "${path}" is not a ${type}`;
+    }
+    const entries = this.entries(source);
+    for (const [field, val] of entries) {
+      if (typeof field !== key) {
+        return `In ${type} "${path}": type of key must be a ${key}`;
+      }
+      if (typeof val !== value) {
+        return `In ${type} "${path}": type of value must be a ${value}`;
+      }
+    }
+  },
+  format(def) {
+    const { type } = this;
+    const { [type]: short } = def;
+    if (def.type) return def;
+    const [key, value] = Object.entries(short)[0];
+    this.key = key;
+    this.value = value;
+  },
+  isInstance(value) {
+    return typeof value === 'object';
+  },
+  entries(value) {
+    return Object.entries(value);
+  },
+};
+
+const map = {
+  ...object,
+  type: 'map',
+  isInstance(value) {
+    return Reflect.getPrototypeOf(value) === Map.prototype;
+  },
+  entries(value) {
+    return value.entries();
+  },
+};
+
+const array = {
+  type: 'array',
+  kind: 'struct',
+  rules: ['length'],
+  validate(value, path, root) {
+    if (!this.isInstance(value)) {
+      return `Field "${path}" value is not a ${this.type}`;
+    }
+    for (const el of value) {
+      const error = this.value.check(el, path, root);
+      if (error.length > 0) return error;
+    }
+  },
+  format(def, prep) {
+    const { type } = this;
+    const source = def.type ? def.value : def[type];
+    const child = prep.parse(source);
+    if (isType(child)) {
+      this.value = child;
+      this.metadataFrom(child);
+    } else {
+      const schema = new prep.types.schema(child.defs, prep);
+      this.references.add('schema');
+      this.metadataFrom(schema);
+      this.value = schema;
+    }
+  },
+  isInstance(value) {
+    return Array.isArray(value);
+  },
+};
+
+const set = {
+  ...array,
+  type: 'set',
+  isInstance(value) {
+    return Reflect.getPrototypeOf(value) === Set.prototype;
+  },
+};
+
+module.exports = { object, map, array, set };

--- a/lib/prototypes/collections.js
+++ b/lib/prototypes/collections.js
@@ -14,13 +14,16 @@ const object = {
     if (entries.length === 0 && this.required) {
       return `Filed "${path}" is required`;
     }
+    const errors = [];
     for (const [field, val] of entries) {
       if (typeof field !== this.key) {
         return `In ${this.type} "${path}": type of key must be a ${this.key}`;
       }
-      const error = this.value.check(val, path, root);
-      if (error.length > 0) return error;
+      const nestedPath = `${path}.${field}`;
+      const err = this.value.check(val, nestedPath, root);
+      if (err) errors.push(...err);
     }
+    if (errors.length > 0) return errors;
   },
   construct(def, prep) {
     const { type } = this;
@@ -30,11 +33,11 @@ const object = {
     const child = prep.parse(v);
     if (isType(child)) {
       this.value = child;
-      this.metadataFrom(child);
+      this.updateMetadata(child);
     } else {
       const schema = new prep.types.schema(child.defs, prep);
       this.references.add('schema');
-      this.metadataFrom(schema);
+      this.updateMetadata(schema);
       this.value = schema;
     }
   },
@@ -50,7 +53,7 @@ const map = {
   ...object,
   type: 'map',
   isInstance(value) {
-    return Reflect.getPrototypeOf(value) === Map.prototype;
+    return value && value.constructor && value.constructor.name === 'Map';
   },
   entries(value) {
     return value.entries();
@@ -61,14 +64,19 @@ const array = {
   type: 'array',
   kind: 'struct',
   rules: ['length'],
-  checkType(value, path, root) {
-    if (!this.isInstance(value)) {
-      return `Field "${path}" value is not a ${this.type}`;
+  checkType(source, path, root) {
+    if (!this.isInstance(source)) {
+      return `Field "${path}" not of expected type: ${this.type}`;
     }
-    for (const el of value) {
-      const error = this.value.check(el, path, root);
-      if (error.length > 0) return error;
+    const value = [...source];
+    const errors = [];
+    for (let i = 0; i < value.length; i++) {
+      const el = value[i];
+      const nestedPath = `${path}[${i}]`;
+      const err = this.value.check(el, nestedPath, root);
+      if (err) errors.push(...err);
     }
+    if (errors.length > 0) return errors;
   },
   construct(def, prep) {
     const { type } = this;
@@ -76,11 +84,11 @@ const array = {
     const child = prep.parse(source);
     if (isType(child)) {
       this.value = child;
-      this.metadataFrom(child);
+      this.updateMetadata(child);
     } else {
       const schema = new prep.types.schema(child.defs, prep);
       this.references.add('schema');
-      this.metadataFrom(schema);
+      this.updateMetadata(schema);
       this.value = schema;
     }
   },
@@ -93,7 +101,7 @@ const set = {
   ...array,
   type: 'set',
   isInstance(value) {
-    return Reflect.getPrototypeOf(value) === Set.prototype;
+    return value && value.constructor && value.constructor.name === 'Set';
   },
 };
 

--- a/lib/prototypes/collections.js
+++ b/lib/prototypes/collections.js
@@ -6,7 +6,7 @@ const object = {
   rules: ['length'],
   type: 'object',
   kind: 'struct',
-  validate(source, path) {
+  checkType(source, path) {
     const { type, key, value } = this;
     if (!this.isInstance(source)) {
       return `Filed "${path}" is not a ${type}`;
@@ -21,7 +21,7 @@ const object = {
       }
     }
   },
-  format(def) {
+  construct(def) {
     const { type } = this;
     const { [type]: short } = def;
     if (def.type) return def;
@@ -52,7 +52,7 @@ const array = {
   type: 'array',
   kind: 'struct',
   rules: ['length'],
-  validate(value, path, root) {
+  checkType(value, path, root) {
     if (!this.isInstance(value)) {
       return `Field "${path}" value is not a ${this.type}`;
     }
@@ -61,7 +61,7 @@ const array = {
       if (error.length > 0) return error;
     }
   },
-  format(def, prep) {
+  construct(def, prep) {
     const { type } = this;
     const source = def.type ? def.value : def[type];
     const child = prep.parse(source);

--- a/lib/prototypes/collections.js
+++ b/lib/prototypes/collections.js
@@ -6,28 +6,37 @@ const object = {
   rules: ['length'],
   type: 'object',
   kind: 'struct',
-  checkType(source, path) {
-    const { type, key, value } = this;
+  checkType(source, path, root) {
     if (!this.isInstance(source)) {
-      return `Filed "${path}" is not a ${type}`;
+      return `Filed "${path}" is not a ${this.type}`;
     }
     const entries = this.entries(source);
+    if (entries.length === 0 && this.required) {
+      return `Filed "${path}" is required`;
+    }
     for (const [field, val] of entries) {
-      if (typeof field !== key) {
-        return `In ${type} "${path}": type of key must be a ${key}`;
+      if (typeof field !== this.key) {
+        return `In ${this.type} "${path}": type of key must be a ${this.key}`;
       }
-      if (typeof val !== value) {
-        return `In ${type} "${path}": type of value must be a ${value}`;
-      }
+      const error = this.value.check(val, path, root);
+      if (error.length > 0) return error;
     }
   },
-  construct(def) {
+  construct(def, prep) {
     const { type } = this;
-    const { [type]: short } = def;
-    if (def.type) return def;
-    const [key, value] = Object.entries(short)[0];
-    this.key = key;
-    this.value = value;
+    const { [type]: short, key, value } = def;
+    const [[k, v]] = short ? Object.entries(short) : [[key, value]];
+    this.key = k;
+    const child = prep.parse(v);
+    if (isType(child)) {
+      this.value = child;
+      this.metadataFrom(child);
+    } else {
+      const schema = new prep.types.schema(child.defs, prep);
+      this.references.add('schema');
+      this.metadataFrom(schema);
+      this.value = schema;
+    }
   },
   isInstance(value) {
     return typeof value === 'object';

--- a/lib/prototypes/reference.js
+++ b/lib/prototypes/reference.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const reference = {
+  kind: 'struct',
+  validate(source, path, root) {
+    const { one, many } = this;
+    if (one) {
+      const schema = root.findReference(one);
+      return schema.check(source, path).errors;
+    }
+    const schema = root.findReference(many);
+    for (const obj of source) {
+      const { valid, errors } = schema.check(obj, path);
+      if (!valid) return errors;
+    }
+  },
+  format(def) {
+    const reference = def.one || def.many;
+    const relation = def.many ? 'many-to-one' : 'one-to-many';
+    this.type = reference;
+    this.references.add(reference);
+    this.relations.add({ to: reference, type: relation });
+  },
+};
+
+module.exports = { reference, many: reference, one: reference };

--- a/lib/prototypes/reference.js
+++ b/lib/prototypes/reference.js
@@ -2,7 +2,7 @@
 
 const reference = {
   kind: 'struct',
-  validate(source, path, root) {
+  checkType(source, path, root) {
     const { one, many } = this;
     if (one) {
       const schema = root.findReference(one);
@@ -14,7 +14,7 @@ const reference = {
       if (!valid) return errors;
     }
   },
-  format(def) {
+  construct(def) {
     const reference = def.one || def.many;
     const relation = def.many ? 'many-to-one' : 'one-to-many';
     this.type = reference;
@@ -23,4 +23,4 @@ const reference = {
   },
 };
 
-module.exports = { reference, many: reference, one: reference };
+module.exports = { reference };

--- a/lib/prototypes/scalars.js
+++ b/lib/prototypes/scalars.js
@@ -4,7 +4,7 @@ const scalar = {
   kind: 'scalar',
   checkType(value, path) {
     if (typeof value !== this.type) {
-      return `Field "${path}" is not of expected type: ${this.type}`;
+      return `Field "${path}" not of expected type: ${this.type}`;
     }
   },
   construct() {},

--- a/lib/prototypes/scalars.js
+++ b/lib/prototypes/scalars.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const scalar = {
+  kind: 'scalar',
+  validate(value, path) {
+    if (typeof value !== this.type) {
+      return `Field "${path}" is not of expected type: ${this.type}`;
+    }
+  },
+  format() {},
+};
+
+const enumerable = {
+  type: 'enum',
+  kind: 'scalar',
+  validate(value, path) {
+    if (this.enum.includes(value)) return;
+    return `Field "${path}" value is not of enum: ${this.enum.join(', ')}`;
+  },
+  format(def) {
+    this.enum = def.enum;
+  },
+};
+
+module.exports = {
+  string: { type: 'string', rules: ['length'], ...scalar },
+  number: { type: 'number', rules: ['length'], ...scalar },
+  bigint: { type: 'bigint', rules: ['length'], ...scalar },
+  boolean: { type: 'boolean', ...scalar },
+  enum: enumerable,
+};

--- a/lib/prototypes/scalars.js
+++ b/lib/prototypes/scalars.js
@@ -2,22 +2,22 @@
 
 const scalar = {
   kind: 'scalar',
-  validate(value, path) {
+  checkType(value, path) {
     if (typeof value !== this.type) {
       return `Field "${path}" is not of expected type: ${this.type}`;
     }
   },
-  format() {},
+  construct() {},
 };
 
 const enumerable = {
   type: 'enum',
   kind: 'scalar',
-  validate(value, path) {
+  checkType(value, path) {
     if (this.enum.includes(value)) return;
     return `Field "${path}" value is not of enum: ${this.enum.join(', ')}`;
   },
-  format(def) {
+  construct(def) {
     this.enum = def.enum;
   },
 };

--- a/lib/prototypes/schema.js
+++ b/lib/prototypes/schema.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const schema = {
+  type: 'schema',
+  kind: 'struct',
+  check(src, path) {
+    if (!this.required && !src) return [];
+    return this.schema.check(src, path).errors;
+  },
+  from(src, prep) {
+    const { schema } = src;
+    const defs = schema || src;
+    this.required = src.required || true;
+    this.schema = this.isSchema(defs) ? defs : prep.Schema.from(defs);
+    this.metadataFrom(this.schema);
+  },
+  isSchema(src) {
+    return src && src.constructor.name === 'Schema';
+  },
+};
+
+module.exports = { schema };

--- a/lib/prototypes/schema.js
+++ b/lib/prototypes/schema.js
@@ -12,7 +12,7 @@ const schema = {
     const defs = schema || src;
     this.required = src.required || true;
     this.schema = this.isSchema(defs) ? defs : prep.Schema.from(defs);
-    this.metadataFrom(this.schema);
+    this.updateMetadata(this.schema);
   },
   isSchema(src) {
     return src && src.constructor.name === 'Schema';

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,25 +2,24 @@
 
 const { toLowerCamel, isFirstUpper } = require('metautil');
 const { formatters, isType } = require('./util.js');
+const {
+  KIND,
+  KIND_STORED,
+  KIND_MEMORY,
+  SCOPE,
+  STORE,
+  ALLOW,
+} = require('./kinds.js');
 const { DEFAULT } = require('./types.js');
 const { Preprocessor } = require('./preprocessor.js');
-
-const KIND_ENT = ['entity', 'registry', 'dictionary'];
-const KIND_AUX = ['journal', 'details', 'relation', 'view'];
-const KIND_STORED = [...KIND_ENT, ...KIND_AUX];
-const KIND_MEMORY = ['struct', 'scalar', 'form', 'projection'];
-const KIND = [...KIND_STORED, ...KIND_MEMORY];
-
-const SCOPE = ['application', 'global', 'local'];
-const STORE = ['persistent', 'memory'];
-const ALLOW = ['write', 'append', 'read'];
 
 const ES_TYPES = ['number', 'string', 'boolean'];
 
 const RESERVED = ['validate', 'parse', 'serialize', 'format'];
 
 class Schema {
-  constructor(name, source, namespaces = []) {
+  constructor(name, raw, namespaces = []) {
+    Schema.KIND = KIND;
     this.kind = 'struct';
     this.scope = 'local';
     this.store = 'memory';
@@ -32,14 +31,13 @@ class Schema {
     this.fields = {};
     this.name = name;
     this.namespaces = new Set(namespaces);
-    const types = this.getTypes();
-    this.prep = new Preprocessor(types, Schema);
-    this.preprocess(this.prep.parse(source));
+    const prep = new Preprocessor(this, Schema);
+    this.preprocess(raw, prep);
     this.options = {
-      validate: source.validate || null,
-      format: source.format || null,
-      parse: source.parse || null,
-      serialize: source.serialize || null,
+      validate: raw.validate || null,
+      format: raw.format || null,
+      parse: raw.parse || null,
+      serialize: raw.serialize || null,
     };
   }
 
@@ -54,7 +52,8 @@ class Schema {
     }
   }
 
-  preprocess(source) {
+  preprocess(raw, prep) {
+    const source = prep.parse(raw);
     if (isType(source)) {
       this.fields = source;
       this.assignMetadata(source);
@@ -67,7 +66,7 @@ class Schema {
       if (RESERVED.includes(key)) continue;
       const entry = defs[key];
       if (this.preprocessIndex(key, entry)) continue;
-      const child = this.prep.parse(entry);
+      const child = prep.parse(entry);
       if (child.skip) {
         this.fields[key] = child.skip;
         continue;
@@ -78,7 +77,7 @@ class Schema {
         child.required = child.required && required;
         this.fields[field] = child;
       } else {
-        const schema = new this.prep.types.schema(child.defs, this.prep);
+        const schema = new prep.types.schema(child.defs, prep);
         schema.required = required;
         this.fields[field] = schema;
         this.references.add('schema');
@@ -220,7 +219,6 @@ class Schema {
   }
 }
 
-Schema.KIND = KIND;
 Schema.KIND_STORED = KIND_STORED;
 Schema.KIND_MEMORY = KIND_MEMORY;
 Schema.SCOPE = SCOPE;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { toLowerCamel, isFirstUpper } = require('metautil');
-const { formatters, isType, harmonize } = require('./util.js');
+const { formatters, isType, prettifyErr } = require('./util.js');
 const {
   KIND,
   KIND_STORED,
@@ -43,9 +43,9 @@ class Schema {
     const field = path || this.name;
     if (!this.options.validate) return;
     try {
-      return harmonize(this.options.validate(value, path), field);
+      return prettifyErr(this.options.validate(value, path), field);
     } catch (err) {
-      return harmonize(`validation failed ${String(err)}`, field);
+      return prettifyErr(`validation failed ${String(err)}`, field);
     }
   }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { toLowerCamel, isFirstUpper } = require('metautil');
-const { formatters, isType } = require('./util.js');
+const { formatters, isType, harmonize } = require('./util.js');
 const {
   KIND,
   KIND_STORED,
@@ -44,9 +44,7 @@ class Schema {
   validate(value, path) {
     if (!this.options.validate) return;
     try {
-      const res = this.options.validate(value, path);
-      if (typeof res === 'boolean') return res ? '' : ['Validation error'];
-      if (res) return Array.isArray(res) ? res : [res];
+      return harmonize(this.options.validate(value, path));
     } catch (err) {
       return [`Field "${path || this.name}" validation failed ${String(err)}`];
     }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -19,7 +19,6 @@ const RESERVED = ['validate', 'parse', 'serialize', 'format'];
 
 class Schema {
   constructor(name, raw, namespaces = []) {
-    Schema.KIND = KIND;
     this.kind = 'struct';
     this.scope = 'local';
     this.store = 'memory';
@@ -31,8 +30,7 @@ class Schema {
     this.fields = {};
     this.name = name;
     this.namespaces = new Set(namespaces);
-    const prep = new Preprocessor(this, Schema);
-    this.preprocess(raw, prep);
+    this.preprocess(raw);
     this.options = {
       validate: raw.validate || null,
       format: raw.format || null,
@@ -42,15 +40,17 @@ class Schema {
   }
 
   validate(value, path) {
+    const field = path || this.name;
     if (!this.options.validate) return;
     try {
-      return harmonize(this.options.validate(value, path));
+      return harmonize(this.options.validate(value, path), field);
     } catch (err) {
-      return [`Field "${path || this.name}" validation failed ${String(err)}`];
+      return harmonize(`validation failed ${String(err)}`, field);
     }
   }
 
-  preprocess(raw, prep) {
+  preprocess(raw) {
+    const prep = new Preprocessor(this, Schema);
     const source = prep.parse(raw);
     if (isType(source)) {
       this.fields = source;
@@ -66,7 +66,7 @@ class Schema {
       if (this.preprocessIndex(key, entry)) continue;
       const child = prep.parse(entry);
       if (child.skip) {
-        this.fields[key] = child.skip;
+        this.fields[key] = entry;
         continue;
       }
       const [field, required] = formatters.key(key, entry.required);
@@ -92,8 +92,8 @@ class Schema {
   }
 
   updateMetadata(meta) {
-    this.references = new Set([...this.references, ...meta.references]);
-    this.relations = new Set([...this.relations, ...meta.relations]);
+    meta.references.forEach(this.references.add, this.references);
+    meta.relations.forEach(this.relations.add, this.relations);
   }
 
   assignMetadata(meta) {
@@ -140,12 +140,11 @@ class Schema {
   }
 
   getTypes() {
-    let types = {};
-    for (const ns of this.namespaces) {
-      if (ns.types) types = { ...types, ...ns.types };
-    }
-    if (Object.keys(types).length === 0) types = DEFAULT;
-    return types;
+    const types = Object.assign(
+      {},
+      ...Array.from(this.namespaces).map((ns) => ns.types)
+    );
+    return Object.keys(types).length === 0 ? { ...DEFAULT } : types;
   }
 
   findReference(name) {
@@ -158,7 +157,7 @@ class Schema {
 
   check(source, path = '') {
     if (isType(this.fields)) {
-      const errors = this.fields.check(source, path);
+      const errors = this.fields.check(source, path, this);
       return { valid: errors.length === 0, errors };
     }
     const err = this.validate(source, path);
@@ -217,6 +216,7 @@ class Schema {
   }
 }
 
+Schema.KIND = KIND;
 Schema.KIND_STORED = KIND_STORED;
 Schema.KIND_MEMORY = KIND_MEMORY;
 Schema.SCOPE = SCOPE;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const { isFirstUpper, toLowerCamel } = require('metautil');
-const { TYPES } = require('./types.js');
+const { toLowerCamel, isFirstUpper } = require('metautil');
+const { formatters, isType } = require('./util.js');
+const { DEFAULT } = require('./types.js');
+const { Preprocessor } = require('./preprocessor.js');
 
 const KIND_ENT = ['entity', 'registry', 'dictionary'];
 const KIND_AUX = ['journal', 'details', 'relation', 'view'];
@@ -15,200 +17,98 @@ const ALLOW = ['write', 'append', 'read'];
 
 const ES_TYPES = ['number', 'string', 'boolean'];
 
-const checks = {
-  array: (arr, type) => {
-    if (!Array.isArray(arr)) return false;
-    for (const el of arr) {
-      if (typeof el !== type) return false;
-    }
-    return true;
-  },
-
-  set: (set, type) => {
-    if (Reflect.getPrototypeOf(set) !== Set.prototype) return false;
-    for (const el of set.values()) {
-      if (typeof el !== type) return false;
-    }
-    return true;
-  },
-
-  object: (obj, key, val) => {
-    if (typeof obj !== 'object') return false;
-    for (const [name, value] of Object.entries(obj)) {
-      if (typeof name !== key) return false;
-      if (typeof value !== val) return false;
-    }
-    return true;
-  },
-
-  map: (map, key, val) => {
-    if (Reflect.getPrototypeOf(map) !== Map.prototype) return false;
-    for (const [name, value] of map.entries()) {
-      if (typeof name !== key) return false;
-      if (typeof value !== val) return false;
-    }
-    return true;
-  },
-};
-
-const getShorthand = (def) => {
-  const keys = Object.keys(def);
-  for (const key of keys) {
-    if (def[key].shorthand) return key;
-  }
-  return '';
-};
-
-const check = (name, def, val) => {
-  if (def.required === false && val === undefined) return [];
-  const { type, key, value, length } = def;
-  if (type === 'array' || type === 'set') {
-    if (checks[type](val, value)) return [];
-    return [`Field "${name}" expected to be ${type} of ${value}`];
-  } else if (type === 'object' || type === 'map') {
-    if (checks[type](val, key, value)) return [];
-    return [`Field "${name}" expected to be ${type} of ${key}: ${value}`];
-  } else if (type === 'enum') {
-    if (def.enum.includes(val)) return [];
-    return [`Field "${name}" value is not of enum: ${def.enum.join(', ')}`];
-  }
-  if (typeof val !== type) {
-    return [`Field "${name}" is not of expected type: ${type}`];
-  }
-  if (length && val) {
-    const len = val.toString().length;
-    const { min, max } = length;
-    if (min && len < min) return [`Field "${name}" value is too short`];
-    if (max && len > max) return [`Field "${name}" exceeds the maximum length`];
-  }
-  return [];
-};
-
-const shorthand = (def) => {
-  if (typeof def === 'string') return def;
-  else if (Array.isArray(def)) return 'tuple';
-  else if (typeof def.array === 'string') return 'array';
-  else if (typeof def.set === 'string') return 'set';
-  else if (typeof def.object === 'object') return 'object';
-  else if (typeof def.map === 'object') return 'map';
-  else if (Array.isArray(def.enum)) return 'enum';
-  return '';
-};
-
-const formatLength = (length) => {
-  if (typeof length === 'number') return { max: length };
-  if (Array.isArray(length)) return { min: length[0], max: length[1] };
-  return length;
-};
-
-const longFormOnlyTypes = new Set(['enum', 'array', 'set', 'map', 'object']);
-const toLongForm = (type, def, key) => {
-  if (typeof def !== 'object' && longFormOnlyTypes.has(type)) {
-    throw new Error(
-      `Short string only definition of "${key}: '${type}'" is not supported`
-    );
-  }
-  if (type === 'enum') {
-    return Object.assign(def, { type, enum: def.enum });
-  } else if (type === 'array' || type === 'set') {
-    const value = def[type];
-    Reflect.deleteProperty(def, type);
-    return Object.assign(def, { type, value });
-  } else if (type === 'map' || type === 'object') {
-    const col = def[type];
-    Reflect.deleteProperty(def, type);
-    const key = Object.keys(col)[0];
-    const value = col[key];
-    return Object.assign(def, { type, key, value });
-  }
-  return { type };
-};
+const RESERVED = ['validate', 'parse', 'serialize', 'format'];
 
 class Schema {
-  constructor(name, raw, namespaces) {
-    const short = shorthand(raw) || raw.type;
-    const defs = short ? { value: raw } : raw;
-    this.name = name;
-    this.kind = short ? 'scalar' : 'struct';
+  constructor(name, source, namespaces = []) {
+    this.kind = 'struct';
     this.scope = 'local';
     this.store = 'memory';
     this.allow = 'write';
-    this.namespaces = new Set(namespaces);
     this.parent = '';
-    this.fields = {};
     this.indexes = {};
     this.references = new Set();
     this.relations = new Set();
-    this.validate = defs.validate || null;
-    this.format = defs.format || null;
-    this.parse = defs.parse || null;
-    this.serialize = defs.serialize || null;
-    this.preprocess(defs);
+    this.fields = {};
+    this.name = name;
+    this.namespaces = new Set(namespaces);
+    const types = this.getTypes();
+    this.prep = new Preprocessor(types, Schema);
+    this.preprocess(this.prep.parse(source));
+    this.options = {
+      validate: source.validate || null,
+      format: source.format || null,
+      parse: source.parse || null,
+      serialize: source.serialize || null,
+    };
   }
 
-  preprocess(defs) {
-    const keys = Object.keys(defs);
-    const first = keys[0];
-    if (isFirstUpper(first)) {
-      const metadata = defs[keys.shift()];
-      this.kind = toLowerCamel(first);
-      this.scope = metadata.scope || 'application';
-      this.store = metadata.store || 'persistent';
-      this.allow = metadata.allow || 'write';
-      if (metadata.schema && metadata.fields) {
-        this.parent = metadata.schema;
-        const parent = this.findReference(this.parent);
-        for (const key of metadata.fields) {
-          defs[key] = parent.fields[key];
-          keys.push(key);
-        }
-      }
+  validate(value, path) {
+    if (!this.options.validate) return;
+    try {
+      const res = this.options.validate(value, path);
+      if (typeof res === 'boolean') return res ? '' : ['Validation error'];
+      if (res) return Array.isArray(res) ? res : [res];
+    } catch (err) {
+      return [`Field "${path || this.name}" validation failed ${String(err)}`];
     }
+  }
+
+  preprocess(source) {
+    if (isType(source)) {
+      this.fields = source;
+      this.assignMetadata(source);
+      return;
+    }
+    const { defs, metadata } = source;
+    const keys = Object.keys(defs);
+    if (metadata) this.assignMetadata(metadata);
     for (const key of keys) {
+      if (RESERVED.includes(key)) continue;
       const entry = defs[key];
-      const short = shorthand(entry);
-      let type = short || entry.type;
-      if (!type) {
-        if (typeof entry === 'function') continue;
-        if (this.preprocessIndex(key, entry)) continue;
-        const schema = Schema.from(entry.schema || entry);
-        const required = !key.endsWith('?');
-        const name = required ? key : key.slice(0, -1);
-        this.fields[name] = Object.assign(
-          { required },
-          entry.schema ? entry : {},
-          { type: 'schema', schema }
-        );
-        this.references = new Set([...this.references, ...schema.references]);
-        this.relations = new Set([...this.relations, ...schema.relations]);
+      if (this.preprocessIndex(key, entry)) continue;
+      const child = this.prep.parse(entry);
+      if (child.skip) {
+        this.fields[key] = child.skip;
         continue;
       }
-      const required = !type.startsWith('?');
-      if (!required) type = type.substring(1);
-      const def = short ? toLongForm(type, entry, key) : { ...entry, type };
-      if (!Reflect.has(def, 'required')) def.required = required;
-      if (def.length) def.length = formatLength(def.length);
-      this.references.add(type);
-      if (isFirstUpper(type)) {
-        this.relations.add({ to: type, type: 'many-to-one' });
+      const [field, required] = formatters.key(key, entry.required);
+      if (isType(child)) {
+        this.updateMetadata(child);
+        child.required = child.required && required;
+        this.fields[field] = child;
+      } else {
+        const schema = new this.prep.types.schema(child.defs, this.prep);
+        schema.required = required;
+        this.fields[field] = schema;
+        this.references.add('schema');
+        this.updateMetadata(schema);
       }
-      this.fields[key] = def;
     }
   }
 
-  preprocessIndex(key, def) {
-    const { index, primary, unique, many } = def;
-    const isIndex = many || Array.isArray(index || primary || unique);
-    if (isIndex) this.indexes[key] = def;
-    if (many) {
-      this.references.add(many);
-      this.relations.add({ to: many, type: 'one-to-many' });
-    }
+  preprocessIndex(key, defs) {
+    const { index, primary, unique, many } = defs;
+    const isIndex = Array.isArray(index || primary || unique);
+    if (isIndex || many) this.indexes[key] = defs;
     return isIndex;
   }
 
-  static from(raw, namespaces) {
-    return new Schema('', raw, namespaces);
+  updateMetadata(meta) {
+    this.references = new Set([...this.references, ...meta.references]);
+    this.relations = new Set([...this.relations, ...meta.relations]);
+  }
+
+  assignMetadata(meta) {
+    this.kind = meta.kind;
+    this.scope = meta.scope || this.scope;
+    this.store = meta.store || this.store;
+    this.allow = meta.allow || this.allow;
+    this.parent = meta.parent || '';
+  }
+
+  static from(source, namespaces) {
+    return new Schema('', source, namespaces);
   }
 
   static extractSchema(def) {
@@ -233,13 +133,22 @@ class Schema {
   }
 
   findType(name) {
-    const type = TYPES[name];
-    if (type) return type;
     for (const ns of this.namespaces) {
       const type = ns.types[name];
       if (type) return type;
     }
+    const type = DEFAULT[name];
+    if (type) return type;
     return null;
+  }
+
+  getTypes() {
+    let types = {};
+    for (const ns of this.namespaces) {
+      if (ns.types) types = { ...types, ...ns.types };
+    }
+    if (Object.keys(types).length === 0) types = DEFAULT;
+    return types;
   }
 
   findReference(name) {
@@ -250,57 +159,31 @@ class Schema {
     return null;
   }
 
-  check(value, path = '') {
-    if (this.validate) {
-      try {
-        const res = this.validate(value, path);
-        const valid = typeof res === 'boolean' ? res : Boolean(res.valid);
-        const errors = (res && res.errors) || [];
-        return { valid, errors };
-      } catch (err) {
-        return {
-          valid: false,
-          errors: [
-            `Field "${path || this.name}" validation failed ${String(err)}`,
-          ],
-        };
-      }
+  check(source, path = '') {
+    if (isType(this.fields)) {
+      const errors = this.fields.check(source, path);
+      return { valid: errors.length === 0, errors };
     }
-    const target = this.kind === 'scalar' ? { value } : value || {};
-    const keys = Object.keys(target);
+    const err = this.validate(source, path);
+    if (err) return { valid: false, errors: err };
+    const keys = Object.keys(source);
     const fields = Object.keys(this.fields);
+    const names = new Set([...fields, ...keys]);
     const errors = [];
-    const shorthand = getShorthand(this.fields);
-    if (shorthand) {
-      const shortDef = this.fields[shorthand];
-      const name = path ? `${path}.${shorthand}` : shorthand;
-      const errs = check(name, shortDef, value);
-      if (errs.length === 0) return { valid: true, errors };
-    }
-    const names = new Set([...keys, ...fields]);
     for (const name of names) {
+      const value = source[name];
+      const type = this.fields[name];
+      if (!type) {
+        errors.push(`Field "${name}" is not expected`);
+        continue;
+      }
       const nestedPath = path ? `${path}.${name}` : name;
-      const value = target[name];
-      let def = this.fields[name];
-      if (def && isFirstUpper(def.type)) {
-        def = this.findReference(def.type);
-      }
-      if (!def) {
-        errors.push(`Field "${nestedPath}" is not expected`);
-        continue;
-      }
-      const schema = Schema.extractSchema(def);
-      if (schema) {
-        if (!def.required && value === undefined) continue;
-        const subcheck = schema.check(value, nestedPath);
-        if (!subcheck.valid) errors.push(...subcheck.errors);
-        continue;
-      }
-      if (def.required && !keys.includes(name)) {
+      if (!type.required && value === undefined) continue;
+      if (type.required && !keys.includes(name)) {
         errors.push(`Field "${nestedPath}" is required`);
         continue;
       }
-      const errs = check(nestedPath, def, value);
+      const errs = type.check(value, nestedPath, this);
       if (errs.length > 0) errors.push(...errs);
     }
     return { valid: errors.length === 0, errors };

--- a/lib/types.js
+++ b/lib/types.js
@@ -3,14 +3,16 @@
 const { AbstractType } = require('./prototypes/abstract.js');
 const scalars = require('./prototypes/scalars.js');
 const collections = require('./prototypes/collections.js');
-const reference = require('./prototypes/reference.js');
-const schema = require('./prototypes/schema.js');
+const { reference } = require('./prototypes/reference.js');
+const { schema } = require('./prototypes/schema.js');
 
 const prototypes = {
   ...scalars,
   ...collections,
-  ...reference,
-  ...schema,
+  reference,
+  many: reference,
+  one: reference,
+  schema,
 };
 
 const construct = (prototype) => {

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,10 +1,54 @@
 'use strict';
 
-const TYPES = {
-  number: 'number',
-  string: 'string',
-  boolean: 'boolean',
-  enum: 'string',
+const { AbstractType } = require('./prototypes/abstract.js');
+const scalars = require('./prototypes/scalars.js');
+const collections = require('./prototypes/collections.js');
+const reference = require('./prototypes/reference.js');
+const schema = require('./prototypes/schema.js');
+
+const prototypes = {
+  ...scalars,
+  ...collections,
+  ...reference,
+  ...schema,
 };
 
-module.exports = { TYPES };
+const construct = (prototype) => {
+  class Type {
+    constructor(def, preprocessor) {
+      this.init();
+      this.from(def, preprocessor);
+    }
+  }
+  Object.assign(Type.prototype, AbstractType, prototype);
+  return Type;
+};
+
+const make = (target = {}) => {
+  for (const [name, proto] of Object.entries(prototypes)) {
+    if (target[name]) continue;
+    target[name] = construct(proto);
+  }
+  return target;
+};
+
+const prepareTypes = (customTypes) => {
+  const res = {};
+  for (const [name, custom] of Object.entries(customTypes)) {
+    if (typeof custom === 'string') {
+      if (!prototypes[name]) {
+        throw new TypeError(`Type ${name} does not exist`);
+      }
+      res[name] = construct({ ...prototypes[name], pg: custom });
+      continue;
+    }
+    const { js, pg } = custom;
+    const proto = js ? { ...prototypes[js], pg } : custom;
+    res[name] = construct(proto);
+  }
+  return make(res);
+};
+
+const DEFAULT = make();
+
+module.exports = { DEFAULT, prepareTypes };

--- a/lib/types.js
+++ b/lib/types.js
@@ -19,10 +19,10 @@ const prototypes = {
 const rulesFrom = (prototype) => {
   const { rules } = prototype;
   if (!rules) return null;
-  const result = { checks: [], formatters: {} };
+  const result = { checks: {}, formatters: {} };
   for (const rule of rules) {
     if (formatters[rule]) result.formatters[rule] = formatters[rule];
-    if (checks[rule]) result.checks.push(checks[rule]);
+    if (checks[rule]) result.checks[rule] = checks[rule];
   }
   return result;
 };

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { formatters, checks } = require('./util.js');
 const { AbstractType } = require('./prototypes/abstract.js');
 const scalars = require('./prototypes/scalars.js');
 const collections = require('./prototypes/collections.js');
@@ -15,6 +16,17 @@ const prototypes = {
   schema,
 };
 
+const rulesFrom = (prototype) => {
+  const { rules } = prototype;
+  if (!rules) return null;
+  const result = { checks: [], formatters: {} };
+  for (const rule of rules) {
+    if (formatters[rule]) result.formatters[rule] = formatters[rule];
+    if (checks[rule]) result.checks.push(checks[rule]);
+  }
+  return result;
+};
+
 const construct = (prototype) => {
   class Type {
     constructor(def, preprocessor) {
@@ -22,7 +34,7 @@ const construct = (prototype) => {
       this.from(def, preprocessor);
     }
   }
-  Object.assign(Type.prototype, AbstractType, prototype);
+  Object.assign(Type.prototype, AbstractType, prototype, rulesFrom(prototype));
   return Type;
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,28 +21,27 @@ const formatters = {
 };
 
 const checks = {
-  length: (src, path, type) => {
+  length: (src, type) => {
     const { length, entries } = type;
+    if (!length) return;
     const value = entries ? entries(src) : src;
     const len = value.length || value;
     const { min, max } = length;
-    if (min && len < min) throw new Error(`Field "${path}" value is too short`);
-    if (max && len > max) {
-      throw new Error(`Field "${path}" exceeds the maximum length`);
-    }
+    if (min && len < min) return 'value is too short';
+    if (max && len > max) return 'exceeds the maximum length';
   },
 };
 
-const harmonize = (result) => {
-  if (typeof result === 'boolean') {
-    return result ? '' : ['Validation error'];
+const harmonize = (err, path = '') => {
+  const prefix = `Field "${path}" `;
+  if (typeof err === 'boolean') {
+    return err ? null : [`${prefix}validation error`];
   }
-  if (result) return Array.isArray(result) ? result : [result];
-};
-
-const omit = (key, obj) => {
-  const { [key]: omitted, ...rest } = obj;
-  return [omitted, rest];
+  if (err) {
+    const unprefixed = Array.isArray(err) ? err : [err];
+    return unprefixed.map((e) => (e.startsWith('Field') ? e : prefix + e));
+  }
+  return null;
 };
 
 const firstKey = (obj) => Object.keys(obj)[0];
@@ -53,7 +52,6 @@ module.exports = {
   formatters,
   checks,
   harmonize,
-  omit,
   firstKey,
   isType,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const formatters = {
+  type: (type, req = true) => {
+    const required = !type.startsWith('?');
+    if (required) return [type, required && req];
+    const name = type.substring(1);
+    return [name, required && req];
+  },
+  key: (key, req = true) => {
+    const required = !key.endsWith('?');
+    if (required) return [key, required && req];
+    const field = key.slice(0, -1);
+    return [field, required];
+  },
+  length: (length) => {
+    if (typeof length === 'number') return { max: length };
+    if (Array.isArray(length)) return { min: length[0], max: length[1] };
+    return length;
+  },
+};
+
+const checks = {
+  length: (src, path, type) => {
+    const { length, entries } = type;
+    const value = entries ? entries(src) : src;
+    const len = value.length || value;
+    const { min, max } = length;
+    if (min && len < min) throw new Error(`Field "${path}" value is too short`);
+    if (max && len > max) {
+      throw new Error(`Field "${path}" exceeds the maximum length`);
+    }
+  },
+};
+
+const omit = (key, obj) => {
+  const { [key]: omitted, ...rest } = obj;
+  return [omitted, rest];
+};
+
+const firstKey = (obj) => Object.keys(obj)[0];
+
+const isType = (obj) => obj.constructor.name === 'Type';
+
+module.exports = {
+  formatters,
+  omit,
+  checks,
+  firstKey,
+  isType,
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,6 +33,13 @@ const checks = {
   },
 };
 
+const harmonize = (result) => {
+  if (typeof result === 'boolean') {
+    return result ? '' : ['Validation error'];
+  }
+  if (result) return Array.isArray(result) ? result : [result];
+};
+
 const omit = (key, obj) => {
   const { [key]: omitted, ...rest } = obj;
   return [omitted, rest];
@@ -44,8 +51,9 @@ const isType = (obj) => obj.constructor.name === 'Type';
 
 module.exports = {
   formatters,
-  omit,
   checks,
+  harmonize,
+  omit,
   firstKey,
   isType,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,7 @@ const checks = {
   },
 };
 
-const harmonize = (err, path = '') => {
+const prettifyErr = (err, path = '') => {
   const prefix = `Field "${path}" `;
   if (typeof err === 'boolean') {
     return err ? null : [`${prefix}validation error`];
@@ -50,7 +50,7 @@ const isType = (obj) => obj.constructor.name === 'Type';
 module.exports = {
   formatters,
   checks,
-  harmonize,
+  prettifyErr,
   firstKey,
   isType,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,7 +23,6 @@ const formatters = {
 const checks = {
   length: (src, type) => {
     const { length, entries } = type;
-    if (!length) return;
     const value = entries ? entries(src) : src;
     const len = value.length || value;
     const { min, max } = length;

--- a/test/collections.js
+++ b/test/collections.js
@@ -261,6 +261,39 @@ metatests.test('Collections: multiple nested arrays', (test) => {
   const schema2 = Schema.from(defs2);
   test.strictSame(schema2.check(obj2).valid, true);
 
+  const obj3 = [
+    {
+      name: 'A',
+      age: 5,
+      nest: {
+        arr1: [1, 2, 3],
+        arr2: [
+          [{ hello: 'world' }, { your: 'world' }],
+          [{ hello: 'world' }, { your: 'world' }],
+        ],
+      },
+    },
+    {
+      name: 'A',
+      age: 5,
+      nest: {
+        arr1: [1, 2, 3],
+        arr2: [
+          [{ hello: 'world' }, { your: 1 }],
+          [{ hello: 'world' }, { your: 2 }],
+        ],
+      },
+    },
+  ];
+
+  test.strictEqual(schema2.check(obj3), {
+    valid: false,
+    errors: [
+      'Field "[1].nest.arr2[0][1].your" not of expected type: string',
+      'Field "[1].nest.arr2[1][1].your" not of expected type: string',
+    ],
+  });
+
   test.end();
 });
 

--- a/test/collections.js
+++ b/test/collections.js
@@ -1,0 +1,284 @@
+'use strict';
+
+const metatests = require('metatests');
+const { Schema } = require('..');
+
+metatests.test('Collections: check collections', (test) => {
+  const def1 = {
+    field1: { array: 'number' },
+  };
+  const obj1 = {
+    field1: [1, 2, 3],
+  };
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check(obj1).valid, true);
+
+  const def2 = {
+    field1: { array: 'number' },
+  };
+  const obj2 = {
+    field1: ['uno', 2, 3],
+  };
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check(obj2).valid, false);
+
+  const def3 = {
+    field1: { object: { string: 'string' } },
+  };
+  const obj3 = {
+    field1: { a: 'A', b: 'B' },
+  };
+  const schema3 = Schema.from(def3);
+  test.strictSame(schema3.check(obj3).valid, true);
+
+  const def4 = {
+    field1: { object: { string: 'string' } },
+  };
+  const obj4 = {
+    field1: { a: 1, b: 'B' },
+  };
+  const schema4 = Schema.from(def4);
+  test.strictSame(schema4.check(obj4).valid, false);
+
+  const def5 = {
+    field1: { set: 'number' },
+  };
+  const obj5 = {
+    field1: new Set([1, 2, 3]),
+  };
+  const schema5 = Schema.from(def5);
+  test.strictSame(schema5.check(obj5).valid, true);
+
+  const def6 = {
+    field1: { set: 'number' },
+  };
+  const obj6 = {
+    field1: new Set(['uno', 2, 3]),
+  };
+  const schema6 = Schema.from(def6);
+  test.strictSame(schema6.check(obj6).valid, false);
+
+  const def7 = {
+    field1: { map: { string: 'string' } },
+  };
+  const obj7 = {
+    field1: new Map([
+      ['a', 'A'],
+      ['b', 'B'],
+    ]),
+  };
+  const schema7 = Schema.from(def7);
+  test.strictSame(schema7.check(obj7).valid, true);
+
+  const def8 = {
+    field1: { map: { string: 'string' } },
+  };
+  const obj8 = {
+    field1: new Set([
+      ['a', 1],
+      ['b', 'B'],
+    ]),
+  };
+  const schema8 = Schema.from(def8);
+  test.strictSame(schema8.check(obj8).valid, false);
+
+  test.end();
+});
+
+metatests.test('Collections: check collections value', (test) => {
+  const def1 = { array: 'number' };
+  const obj1 = [1, 2, 3];
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check(obj1).valid, true);
+
+  const def2 = { array: 'number' };
+  const obj2 = ['uno', 2, 3];
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check(obj2).valid, false);
+
+  const def3 = { object: { string: 'string' } };
+  const obj3 = { a: 'A', b: 'B' };
+  const schema3 = Schema.from(def3);
+  test.strictSame(schema3.check(obj3).valid, true);
+
+  const def4 = { object: { string: 'string' } };
+  const obj4 = { a: 1, b: 'B' };
+  const schema4 = Schema.from(def4);
+  test.strictSame(schema4.check(obj4).valid, false);
+
+  const def5 = { set: 'number' };
+  const obj5 = new Set([1, 2, 3]);
+  const schema5 = Schema.from(def5);
+  test.strictSame(schema5.check(obj5).valid, true);
+
+  const def6 = { set: 'number' };
+  const obj6 = new Set(['uno', 2, 3]);
+  const schema6 = Schema.from(def6);
+  test.strictSame(schema6.check(obj6).valid, false);
+
+  const def7 = { map: { string: 'string' } };
+  const obj7 = new Map([
+    ['a', 'A'],
+    ['b', 'B'],
+  ]);
+  const schema7 = Schema.from(def7);
+  test.strictSame(schema7.check(obj7).valid, true);
+
+  const def8 = { map: { string: 'string' } };
+  const obj8 = new Set([
+    ['a', 1],
+    ['b', 'B'],
+  ]);
+  const schema8 = Schema.from(def8);
+  test.strictSame(schema8.check(obj8).valid, false);
+
+  test.end();
+});
+
+metatests.test('Collections: check value with long form', (test) => {
+  const def1 = { type: 'array', value: 'number' };
+  const obj1 = [1, 2, 3];
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check(obj1).valid, true);
+
+  const def2 = { type: 'array', value: 'number' };
+  const obj2 = ['uno', 2, 3];
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check(obj2).valid, false);
+
+  const def3 = { type: 'object', key: 'string', value: 'string' };
+  const obj3 = { a: 'A', b: 'B' };
+  const schema3 = Schema.from(def3);
+  test.strictSame(schema3.check(obj3).valid, true);
+
+  const def4 = { type: 'object', key: 'string', value: 'string' };
+  const obj4 = { a: 1, b: 'B' };
+  const schema4 = Schema.from(def4);
+  test.strictSame(schema4.check(obj4).valid, false);
+
+  const def5 = { type: 'set', value: 'number' };
+  const obj5 = new Set([1, 2, 3]);
+  const schema5 = Schema.from(def5);
+  test.strictSame(schema5.check(obj5).valid, true);
+
+  const def6 = { type: 'set', value: 'number' };
+  const obj6 = new Set(['uno', 2, 3]);
+  const schema6 = Schema.from(def6);
+  test.strictSame(schema6.check(obj6).valid, false);
+
+  const def7 = { type: 'map', key: 'string', value: 'string' };
+  const obj7 = new Map([
+    ['a', 'A'],
+    ['b', 'B'],
+  ]);
+  const schema7 = Schema.from(def7);
+  test.strictSame(schema7.check(obj7).valid, true);
+
+  const def8 = { type: 'map', key: 'string', value: 'string' };
+  const obj8 = new Set([
+    ['a', 1],
+    ['b', 'B'],
+  ]);
+  const schema8 = Schema.from(def8);
+  test.strictSame(schema8.check(obj8).valid, false);
+
+  const def9 = { type: 'enum', enum: ['foo', 'bar'] };
+  const schema9 = Schema.from(def9);
+  test.strictSame(schema9.check('foo').valid, true);
+  test.strictSame(schema9.check('bar').valid, true);
+  test.strictSame(schema9.check('baz').valid, false);
+
+  test.end();
+});
+
+metatests.test('Collections: multiple nested arrays', (test) => {
+  const defs1 = {
+    Entity: {},
+    name: {
+      first: { type: 'string' },
+      last: { type: 'string' },
+      third: { type: '?string' },
+    },
+    age: { type: 'number' },
+    levelOne: {
+      levelTwo: {
+        levelThree: { type: 'enum', enum: [1, 2, 3] },
+      },
+    },
+    collection: { array: { array: 'number' } },
+  };
+
+  const schema1 = Schema.from(defs1);
+
+  const obj1 = {
+    name: {
+      first: 'a',
+      last: 'b',
+    },
+    age: 5,
+    levelOne: { levelTwo: { levelThree: 1 } },
+    collection: [
+      [1, 2, 3],
+      [3, 5, 6],
+    ],
+  };
+  test.strictSame(schema1.check(obj1).valid, true);
+
+  const defs2 = {
+    array: {
+      name: 'string',
+      age: 'number',
+      nest: {
+        arr1: { array: { enum: [1, 2, 3] } },
+        arr2: { array: { array: { object: { string: 'string' } } } },
+      },
+    },
+  };
+  const obj2 = [
+    {
+      name: 'A',
+      age: 5,
+      nest: {
+        arr1: [1, 2, 3],
+        arr2: [
+          [{ hello: 'world' }, { your: 'world' }],
+          [{ hello: 'world' }, { your: 'world' }],
+        ],
+      },
+    },
+    {
+      name: 'A',
+      age: 5,
+      nest: {
+        arr1: [1, 2, 3],
+        arr2: [
+          [{ hello: 'world' }, { your: 'world' }],
+          [{ hello: 'world' }, { your: 'world' }],
+        ],
+      },
+    },
+  ];
+  const schema2 = Schema.from(defs2);
+  test.strictSame(schema2.check(obj2).valid, true);
+
+  test.end();
+});
+
+metatests.test('Collections: optional shorthand key', (test) => {
+  const defs1 = { 'array?': 'string' };
+  const defs2 = { 'object?': { string: 'string' } };
+  const defs3 = { 'set?': 'string' };
+  const defs4 = { 'map?': { string: 'string' } };
+
+  const sch1 = Schema.from(defs1);
+  const sch2 = Schema.from(defs2);
+  const sch3 = Schema.from(defs3);
+  const sch4 = Schema.from(defs4);
+
+  test.strictSame(sch1.check([]).valid, true);
+  test.strictSame(sch2.check({}).valid, true);
+  test.strictSame(sch3.check(new Set()).valid, true);
+  test.strictSame(sch4.check(new Map()).valid, true);
+
+  test.end();
+});

--- a/test/collections.js
+++ b/test/collections.js
@@ -282,3 +282,45 @@ metatests.test('Collections: optional shorthand key', (test) => {
 
   test.end();
 });
+
+metatests.test('Collections: nested object', (test) => {
+  const defs1 = { object: { string: { array: 'string' } } };
+  const defs2 = { type: 'object', key: 'string', value: { array: 'string' } };
+  const defs3 = {
+    type: 'object',
+    key: 'string',
+    value: {
+      type: 'array',
+      value: {
+        type: 'object',
+        key: 'string',
+        value: { type: 'object', key: 'string', value: { name: 'string' } },
+      },
+    },
+  };
+  const defs4 = { 'object?': { string: { array: 'string' } } };
+
+  const sch1 = Schema.from(defs1);
+  const sch2 = Schema.from(defs2);
+  const sch3 = Schema.from(defs3);
+  const sch4 = Schema.from(defs4);
+
+  test.strictSame(sch1.check({ key: ['hello', 'there'] }).valid, true);
+  test.strictSame(sch1.check({ key: 'hello' }).valid, false);
+  test.strictSame(sch1.check({}).valid, false);
+  test.strictSame(sch2.check({ key: ['hello', 'there'] }).valid, true);
+  test.strictSame(sch2.check({ key: 'hello' }).valid, false);
+  test.strictSame(sch2.check({}).valid, false);
+  test.strictSame(
+    sch3.check({ key: [{ key: { key: { name: 'Georg' } } }] }).valid,
+    true
+  );
+  test.strictSame(
+    sch3.check({ key: [{ key: { name: 'Georg' } }] }).valid,
+    false
+  );
+  test.strictSame(sch4.check({}).valid, true);
+  test.strictSame(sch4.fields.required, false);
+
+  test.end();
+});

--- a/test/database.js
+++ b/test/database.js
@@ -3,9 +3,9 @@
 const metatests = require('metatests');
 const { Schema } = require('..');
 
-metatests.test('Schema: database', (test) => {
+metatests.test('Database: schema Registry', (test) => {
   const raw = {
-    Registry: {},
+    Registry: { scope: 'application', store: 'persistent', allow: 'write' },
 
     name: { type: 'string', unique: true },
     street: 'string',
@@ -21,56 +21,85 @@ metatests.test('Schema: database', (test) => {
   };
 
   const expected = {
-    name: 'Address',
-    namespaces: new Set(),
-    parent: '',
     kind: 'registry',
     scope: 'application',
     store: 'persistent',
     allow: 'write',
-    fields: {
-      name: { type: 'string', unique: true, required: true },
-      street: { type: 'string', required: true },
-      building: { type: 'string', required: true },
-      apartment: { type: 'string', required: true },
-      location: {
-        type: 'schema',
-        required: true,
-        schema: {
-          name: '',
-          namespaces: new Set(),
-          parent: '',
-          kind: 'struct',
-          scope: 'local',
-          store: 'memory',
-          allow: 'write',
-          fields: {
-            country: { required: true, type: 'Country' },
-          },
-          indexes: {},
-          references: new Set(['Country']),
-          relations: new Set([{ to: 'Country', type: 'many-to-one' }]),
-          validate: null,
-          format: null,
-          parse: null,
-          serialize: null,
-        },
-      },
-    },
+    parent: '',
     indexes: {
       persons: { many: 'Person' },
       naturalKey: { primary: ['street', 'building', 'apartment'] },
       altKey: { unique: ['name', 'street'] },
     },
-    references: new Set(['string', 'Country', 'Person']),
+    references: new Set(['string', 'schema', 'Country', 'Person']),
     relations: new Set([
-      { to: 'Country', type: 'many-to-one' },
-      { to: 'Person', type: 'one-to-many' },
+      { to: 'Country', type: 'one-to-many' },
+      { to: 'Person', type: 'many-to-one' },
     ]),
-    validate: null,
-    format: null,
-    parse: null,
-    serialize: null,
+    fields: {
+      name: {
+        references: new Set(['string']),
+        relations: new Set(),
+        required: true,
+        unique: true,
+        type: 'string',
+      },
+      street: {
+        references: new Set(['string']),
+        relations: new Set(),
+        required: true,
+        type: 'string',
+      },
+      building: {
+        references: new Set(['string']),
+        relations: new Set(),
+        required: true,
+        type: 'string',
+      },
+      apartment: {
+        references: new Set(['string']),
+        relations: new Set(),
+        required: true,
+        type: 'string',
+      },
+      location: {
+        references: new Set(['Country']),
+        relations: new Set([{ to: 'Country', type: 'one-to-many' }]),
+        required: true,
+        schema: {
+          kind: 'struct',
+          scope: 'local',
+          store: 'memory',
+          allow: 'write',
+          parent: '',
+          indexes: {},
+          references: new Set(['Country']),
+          relations: new Set([{ to: 'Country', type: 'one-to-many' }]),
+          fields: {
+            country: {
+              references: new Set('Country'),
+              relations: new Set([{ to: 'Country', type: 'one-to-many' }]),
+              one: 'Country',
+              required: true,
+              type: 'Country',
+            },
+          },
+          name: '',
+          namespaces: new Set(),
+        },
+        options: { validate: null, format: null, parse: null, serialize: null },
+      },
+      persons: {
+        references: new Set(['Person']),
+        relations: new Set([{ to: 'Person', type: 'many-to-one' }]),
+        many: 'Person',
+        required: true,
+        type: 'Person',
+      },
+    },
+    name: 'Address',
+    namespaces: new Set(),
+    options: { validate: null, format: null, parse: null, serialize: null },
   };
 
   const entity = new Schema('Address', raw);

--- a/test/database.js
+++ b/test/database.js
@@ -5,7 +5,7 @@ const { Schema } = require('..');
 
 metatests.test('Database: schema Registry', (test) => {
   const raw = {
-    Registry: { scope: 'application', store: 'persistent', allow: 'write' },
+    Registry: {},
 
     name: { type: 'string', unique: true },
     street: 'string',

--- a/test/loader.js
+++ b/test/loader.js
@@ -1,7 +1,16 @@
 'use strict';
 
 const metatests = require('metatests');
-const { createSchema, loadSchema } = require('..');
+const { createSchema, loadSchema, loadModel } = require('..');
+
+const types = {
+  string: 'varchar',
+  number: 'integer',
+  boolean: 'boolean',
+  datetime: { js: 'string', pg: 'timestamp with time zone' },
+  text: { js: 'string', pg: 'text' },
+  json: { js: 'schema', pg: 'jsonb' },
+};
 
 metatests.test('Schema: createSchema', (test) => {
   const definition = `({ field1: 'string' })`;
@@ -15,5 +24,17 @@ metatests.test('Schema: loadSchema', async (test) => {
   const schema = await loadSchema('./test/examples/struct.js');
   test.strictSame(schema.fields.field1.type, 'string');
   test.strictSame(schema.fields.field2.type, 'number');
+  test.end();
+});
+
+metatests.test('Model: loadModel', async (test) => {
+  const model = await loadModel(process.cwd() + '/test/schemas', types);
+  test.strictEqual(model.entities.size, 5);
+  const Account = model.entities.get('Account');
+  test.strictEqual(Account.fields.fullName.type, 'schema');
+  test.strictEqual(Account.fields.fullName.schema.constructor.name, 'Schema');
+  test.strictEqual(model.order.size, 5);
+  test.strictEqual(typeof model.types, 'object');
+  test.strictEqual(typeof model.database, 'object');
   test.end();
 });

--- a/test/loader.js
+++ b/test/loader.js
@@ -12,7 +12,7 @@ const types = {
   json: { js: 'schema', pg: 'jsonb' },
 };
 
-metatests.test('Schema: createSchema', (test) => {
+metatests.test('Loader: createSchema', (test) => {
   const definition = `({ field1: 'string' })`;
   const schema = createSchema('StructName', definition);
   test.strictSame(typeof schema.fields, 'object');
@@ -20,21 +20,27 @@ metatests.test('Schema: createSchema', (test) => {
   test.end();
 });
 
-metatests.test('Schema: loadSchema', async (test) => {
+metatests.test('Loader: loadSchema', async (test) => {
   const schema = await loadSchema('./test/examples/struct.js');
   test.strictSame(schema.fields.field1.type, 'string');
   test.strictSame(schema.fields.field2.type, 'number');
   test.end();
 });
 
-metatests.test('Model: loadModel', async (test) => {
+metatests.test('Loader: loadModel, projection', async (test) => {
   const model = await loadModel(process.cwd() + '/test/schemas', types);
-  test.strictEqual(model.entities.size, 5);
+  test.strictEqual(model.entities.size, 6);
   const Account = model.entities.get('Account');
   test.strictEqual(Account.fields.fullName.type, 'schema');
   test.strictEqual(Account.fields.fullName.schema.constructor.name, 'Schema');
-  test.strictEqual(model.order.size, 5);
+  test.strictEqual(model.order.size, 6);
   test.strictEqual(typeof model.types, 'object');
   test.strictEqual(typeof model.database, 'object');
+  const Projection = model.entities.get('Signin');
+  test.strictEqual(Projection.fields.login, Account.fields.login);
+  test.strictEqual(Projection.fields.password, Account.fields.password);
+  const EarlyProjection = model.entities.get('Aaa');
+  test.strictEqual(Projection.fields.login, EarlyProjection.fields.login);
+  test.strictEqual(Projection.fields.password, EarlyProjection.fields.password);
   test.end();
 });

--- a/test/model.js
+++ b/test/model.js
@@ -69,3 +69,34 @@ metatests.test('Model: from struct', (test) => {
 
   test.end();
 });
+
+metatests.test('Model: many relation Schema for validation', (test) => {
+  const entities = new Map();
+
+  entities.set('Company', {
+    Dictionary: {},
+    name: { type: 'string', unique: true },
+    addresses: { many: 'Address' },
+  });
+
+  entities.set('Address', {
+    Entity: {},
+    city: { type: 'string', unique: true },
+  });
+
+  const model = new Model(types, entities, database);
+
+  const company = model.entities.get('Company');
+
+  const obj = {
+    name: 'Galeere',
+    addresses: [{ city: 'Berlin' }, { city: 'Kiev' }],
+  };
+
+  const obj1 = { name: 'Leere' };
+
+  test.strictSame(company.check(obj).valid, true);
+  test.strictSame(company.check(obj1).valid, false);
+
+  test.end();
+});

--- a/test/rules.js
+++ b/test/rules.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const metatests = require('metatests');
+const { Schema } = require('..');
+
+metatests.test('Rules: length, required', (test) => {
+  const definition = {
+    field1: 'string',
+    field2: { type: 'number' },
+    field3: { type: 'string', length: 30 },
+    field4: { type: 'string', length: { min: 10 } },
+    field5: { type: 'string', length: [5, 60] },
+  };
+  const schema = Schema.from(definition);
+  test.strictSame(schema.fields.field1.type, 'string');
+  test.strictSame(schema.fields.field2.required, true);
+  test.strictSame(schema.fields.field3.length.max, 30);
+  test.strictSame(schema.fields.field4.length.min, 10);
+  test.strictSame(schema.fields.field5.length.max, 60);
+  test.strictSame(schema.fields.field5.length.min, 5);
+  test.end();
+});
+
+metatests.test('Rules: check', (test) => {
+  const definition = {
+    field1: 'string',
+    field2: { type: 'number' },
+    field3: { type: 'string', length: 30 },
+    field4: { type: 'string', required: false },
+    field5: {
+      subfield1: 'number',
+      subfield2: { type: 'string', required: false },
+    },
+  };
+  const obj = {
+    field1: 'value',
+    field2: 100,
+    field3: 'value',
+    field5: {
+      subfield1: 500,
+      subfield2: 'value',
+    },
+  };
+  const schema = Schema.from(definition);
+  test.strictSame(schema.check(obj).valid, true);
+  test.end();
+});
+
+metatests.test('Rules: length negative check', (test) => {
+  const definition = {
+    field1: 'string',
+    field2: { type: 'number' },
+    field3: { type: 'string', length: { min: 5, max: 30 } },
+  };
+  const schema = Schema.from(definition);
+
+  const obj1 = {
+    field1: 1,
+    field2: 100,
+    field3: 'value',
+  };
+  test.strictSame(schema.check(obj1).valid, false);
+
+  const obj2 = {
+    field1: 'value',
+    field2: 'value',
+    field3: 'value',
+  };
+  test.strictSame(schema.check(obj2).valid, false);
+
+  const obj3 = {
+    field1: 'value',
+    field2: 100,
+    field3: 'valuevaluevaluevaluevaluevaluevaluevalue',
+  };
+  test.strictSame(schema.check(obj3).valid, false);
+
+  const obj4 = {
+    field1: 'value',
+    field2: 100,
+    field3: 'val',
+  };
+  test.strictSame(schema.check(obj4).valid, false);
+
+  const obj5 = {
+    field1: 'value',
+    field2: 100,
+  };
+  test.strictSame(schema.check(obj5).valid, false);
+  test.end();
+});

--- a/test/scalars.js
+++ b/test/scalars.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const metatests = require('metatests');
+const { Schema } = require('../metaschema');
+
+metatests.test('Scalars: schema shorthand', (test) => {
+  const definition = {
+    field1: {
+      n: { type: 'number', default: 100 },
+      c: { type: 'string', shorthand: true },
+    },
+  };
+  const schema = Schema.from(definition);
+
+  const obj1 = { field1: 'value' };
+  test.strictSame(schema.check(obj1).valid, false);
+
+  const obj2 = { field1: 1 };
+  test.strictSame(schema.check(obj2).valid, false);
+
+  const obj3 = { field1: { n: 1, c: 'value' } };
+  test.strictSame(schema.check(obj3).valid, true);
+
+  test.end();
+});
+
+metatests.test('Scalars: schema required shorthand', (test) => {
+  const definition1 = { name: '?string' };
+  const schema1 = Schema.from(definition1);
+
+  const definition2 = { name: { type: '?string' } };
+  const schema2 = Schema.from(definition2);
+
+  const obj1 = { name: 'value' };
+  test.strictSame(schema1.check(obj1).valid, true);
+  test.strictSame(schema2.check(obj1).valid, true);
+
+  const obj2 = {};
+  test.strictSame(schema1.check(obj2).valid, true);
+  test.strictSame(schema2.check(obj2).valid, true);
+
+  const obj3 = { name: 100 };
+  test.strictSame(schema1.check(obj3).valid, false);
+  test.strictSame(schema2.check(obj3).valid, false);
+
+  test.end();
+});
+
+metatests.test('Scalars: check scalar', (test) => {
+  const def1 = { type: 'string' };
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check('value').valid, true);
+  test.strictSame(schema1.check(1917).valid, false);
+  test.strictSame(schema1.check(true).valid, false);
+  test.strictSame(schema1.check({}).valid, false);
+
+  const def2 = 'string';
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check('value').valid, true);
+  test.strictSame(schema2.check(1917).valid, false);
+  test.strictSame(schema2.check(true).valid, false);
+  test.strictSame(schema2.check({}).valid, false);
+
+  test.end();
+});
+
+metatests.test('Scalars: check enum', (test) => {
+  const definition = { field: { enum: ['uno', 'due', 'tre'] } };
+  const schema = Schema.from(definition);
+  test.strictSame(schema.check({ field: 'uno' }).valid, true);
+  test.strictSame(schema.check({ field: 'due' }).valid, true);
+  test.strictSame(schema.check({ field: 'tre' }).valid, true);
+  test.strictSame(schema.check({ field: 'quatro' }).valid, false);
+  test.strictSame(schema.check({ field: 100 }).valid, false);
+  test.strictSame(schema.check({}).valid, false);
+
+  const def1 = { field: { enum: ['uno', 'due', 'tre'], required: false } };
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check({ field: 'uno' }).valid, true);
+
+  const def2 = { field: { enum: ['uno', 'due', 'tre'], required: false } };
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check({ field: 'quatro' }).valid, false);
+
+  const def3 = { field: { enum: ['uno', 'due', 'tre'], required: false } };
+  const schema3 = Schema.from(def3);
+  test.strictSame(schema3.check({}).valid, true);
+
+  const def4 = { field: { array: 'number', required: false } };
+  const schema4 = Schema.from(def4);
+  test.strictSame(schema4.check({ field: [1, 2, 3] }).valid, true);
+
+  const def5 = { field: { array: 'number', required: false } };
+  const schema5 = Schema.from(def5);
+  test.strictSame(schema5.check({ field: ['uno', 2, 3] }).valid, false);
+
+  const def6 = { field: { array: 'number', required: false } };
+  const schema6 = Schema.from(def6);
+  test.strictSame(schema6.check({}).valid, true);
+
+  test.end();
+});
+
+metatests.test('Scalars: check enum value', (test) => {
+  const def1 = { enum: ['uno', 'due', 'tre'] };
+  const schema1 = Schema.from(def1);
+  test.strictSame(schema1.check('uno').valid, true);
+  test.strictSame(schema1.check('due').valid, true);
+  test.strictSame(schema1.check('tre').valid, true);
+  test.strictSame(schema1.check('quatro').valid, false);
+  test.strictSame(schema1.check(100).valid, false);
+
+  const def2 = { enum: ['uno', 'due', 'tre'], required: false };
+  const schema2 = Schema.from(def2);
+  test.strictSame(schema2.check('uno').valid, true);
+  test.strictSame(schema2.check('due').valid, true);
+  test.strictSame(schema2.check('tre').valid, true);
+  test.strictSame(schema2.check('quatro').valid, false);
+  test.strictSame(schema2.check(100).valid, false);
+
+  test.end();
+});

--- a/test/schema.js
+++ b/test/schema.js
@@ -290,29 +290,31 @@ metatests.test('Schema: custom validate on field', (test) => {
     email: {
       type: 'string',
       required: true,
-      length: { max: 15 },
+      length: { min: 2, max: 15 },
       validate(src) {
-        if (typeof src !== 'string') return false;
-        if (src.length <= 2) {
-          return false;
-        }
         if (src.indexOf('@') === -1) {
-          return false;
+          return 'Not an Email';
         }
         const [, domain] = src.split('@');
-        if (domain.length <= 2) return false;
-        return true;
+        if (domain.length <= 2) return 'Not an Email';
       },
     },
   };
 
   const schema1 = Schema.from(defs1);
-  test.strictEqual(schema1.check({ email: 'asd' }).valid, false);
+  test.strictEqual(schema1.check({ email: 12345 }), {
+    valid: false,
+    errors: ['Field "email" is not of expected type: string'],
+  });
+  test.strictEqual(schema1.check({ email: 'ab' }), {
+    valid: false,
+    errors: ['Not an Email'],
+  });
   test.strictEqual(schema1.check({ email: 'asd@asd.com' }).valid, true);
-  test.strictEqual(
-    schema1.check({ email: 'asdasdasdasdasdasd@asd.com' }).valid,
-    false
-  );
+  test.strictEqual(schema1.check({ email: 'asdasdasdasdasdasd@asd.com' }), {
+    valid: false,
+    errors: ['Field "email" exceeds the maximum length'],
+  });
   const defs2 = {
     type: 'number',
     validate(num) {

--- a/test/schema.js
+++ b/test/schema.js
@@ -134,7 +134,7 @@ metatests.test('Schema: validation function', (test) => {
     schema.check({
       field2: 'abc',
     }),
-    { valid: false, errors: ['.field is required'] }
+    { valid: false, errors: ['Field "" .field is required'] }
   );
 
   test.strictSame(
@@ -157,7 +157,7 @@ metatests.test('Schema: validation function simple return', (test) => {
   test.strictSame(schema.check({ field: '42' }), { valid: true, errors: [] });
   test.strictSame(schema.check({ field: '43' }), {
     valid: false,
-    errors: ['Validation error'],
+    errors: ['Field "" validation error'],
   });
 
   test.end();
@@ -214,7 +214,7 @@ metatests.test('Schema: nested validation function', (test) => {
         field2: 'abc',
       },
     }),
-    { valid: false, errors: ['nested.field is required'] }
+    { valid: false, errors: ['Field "nested" nested.field is required'] }
   );
 
   test.strictSame(
@@ -304,11 +304,11 @@ metatests.test('Schema: custom validate on field', (test) => {
   const schema1 = Schema.from(defs1);
   test.strictEqual(schema1.check({ email: 12345 }), {
     valid: false,
-    errors: ['Field "email" is not of expected type: string'],
+    errors: ['Field "email" not of expected type: string'],
   });
   test.strictEqual(schema1.check({ email: 'ab' }), {
     valid: false,
-    errors: ['Not an Email'],
+    errors: ['Field "email" Not an Email'],
   });
   test.strictEqual(schema1.check({ email: 'asd@asd.com' }).valid, true);
   test.strictEqual(schema1.check({ email: 'asdasdasdasdasdasd@asd.com' }), {
@@ -336,11 +336,17 @@ metatests.test('Schema: custom validate on field', (test) => {
   const schema2 = Schema.from(defs2);
   const schema3 = Schema.from(defs3);
   const schema4 = Schema.from(defs4);
-  test.strictSame(schema2.check(12), { valid: false, errors: ['Not a ten'] });
-  test.strictSame(schema3.check(12), { valid: false, errors: ['Not a ten'] });
+  test.strictSame(schema2.check(12), {
+    valid: false,
+    errors: ['Field "" validation failed Error: Not a ten'],
+  });
+  test.strictSame(schema3.check(12), {
+    valid: false,
+    errors: ['Field "" Not a ten'],
+  });
   test.strictSame(schema4.check(12), {
     valid: false,
-    errors: ['Not', 'a', 'ten'],
+    errors: ['Field "" Not', 'Field "" a', 'Field "" ten'],
   });
   test.strictSame(schema2.check(10).valid, true);
   test.strictSame(schema3.check(10).valid, true);

--- a/test/schema.js
+++ b/test/schema.js
@@ -13,10 +13,10 @@ metatests.test('Schema: constructor', (test) => {
   test.strictSame(schema.allow, 'write');
   test.strictSame(typeof schema.fields, 'object');
   test.strictSame(typeof schema.indexes, 'object');
-  test.strictSame(schema.validate, null);
-  test.strictSame(schema.format, null);
-  test.strictSame(schema.parse, null);
-  test.strictSame(schema.serialize, null);
+  test.strictSame(schema.options.validate, null);
+  test.strictSame(schema.options.format, null);
+  test.strictSame(schema.options.parse, null);
+  test.strictSame(schema.options.serialize, null);
   test.strictSame(schema.fields.field1.type, 'string');
   test.end();
 });
@@ -33,525 +33,17 @@ metatests.test('Schema: factory', (test) => {
   test.end();
 });
 
-metatests.test('Schema: preprocess', (test) => {
-  const definition = {
-    field1: 'string',
-    field2: { type: 'number' },
-    field3: { type: 'string', length: 30 },
-    field4: { type: 'string', length: { min: 10 } },
-    field5: { type: 'string', length: [5, 60] },
-  };
-  const schema = Schema.from(definition);
-  test.strictSame(schema.fields.field1.type, 'string');
-  test.strictSame(schema.fields.field2.required, true);
-  test.strictSame(schema.fields.field3.length.max, 30);
-  test.strictSame(schema.fields.field4.length.min, 10);
-  test.strictSame(schema.fields.field5.length.max, 60);
-  test.strictSame(schema.fields.field5.length.min, 5);
-  test.end();
-});
-
-metatests.test('Schema: check', (test) => {
-  const definition = {
-    field1: 'string',
-    field2: { type: 'number' },
-    field3: { type: 'string', length: 30 },
-    field4: { type: 'string', required: false },
-    field5: {
-      subfield1: 'number',
-      subfield2: { type: 'string', required: false },
-    },
-  };
-  const obj = {
-    field1: 'value',
-    field2: 100,
-    field3: 'value',
-    field5: {
-      subfield1: 500,
-      subfield2: 'value',
-    },
-  };
-  const schema = Schema.from(definition);
-  test.strictSame(schema.check(obj).valid, true);
-  test.end();
-});
-
-metatests.test('Schema: nested schema', (test) => {
-  const definition = {
-    field1: 'string',
-    field2: {
-      schema: {
-        subfield1: 'number',
-        subfield2: 'string',
-      },
-    },
-  };
-  const obj = {
-    field1: 'value',
-    field2: {
-      subfield1: 500,
-      subfield2: 'value',
-    },
-  };
-  const schema = Schema.from(definition);
-  test.strictSame(schema.check(obj).valid, true);
-  test.end();
-});
-
-metatests.test('Schema: nested schema, lost field', (test) => {
-  const schema = Schema.from({
-    field1: 'string',
-    field2: {
-      subfield1: 'number',
-    },
-    field3: 'string',
-  });
-
-  const obj = {
-    field1: 'value',
-  };
-  test.strictSame(schema.check(obj), {
-    valid: false,
-    errors: [
-      'Field "field2.subfield1" is required',
-      'Field "field3" is required',
-    ],
-  });
-
-  test.end();
-});
-
-metatests.test('Schema: optional nested struct', (test) => {
-  const definition = {
-    struct: {
-      required: false,
-      schema: {
-        field: 'string',
-      },
-    },
-  };
-  const schema = Schema.from(definition);
-
-  const obj1 = {};
-  test.strictSame(schema.check(obj1).valid, true);
-
-  const obj2 = {
-    struct: {
-      field: 'value',
-    },
-  };
-  test.strictSame(schema.check(obj2).valid, true);
-
-  test.end();
-});
-
-metatests.test('Schema: optional nested struct base object', (test) => {
-  const definition = {
-    text: 'string',
-    struct: {
-      required: false,
-      schema: {
-        field: 'string',
-      },
-    },
-  };
-  const schema = Schema.from(definition);
-
-  const obj1 = { text: 'abc' };
-  test.strictSame(schema.check(obj1), { valid: true, errors: [] });
-
-  const obj2 = {
-    text: 'abc',
-    struct: {
-      field: 'value',
-    },
-  };
-  test.strictSame(schema.check(obj2), { valid: true, errors: [] });
-
-  test.end();
-});
-
-metatests.test('Schema: shorthand for optional nested struct', (test) => {
-  const definition = {
-    'struct?': {
-      field: 'string',
-    },
-  };
-  const schema = Schema.from(definition);
-
-  const obj1 = {};
-  test.strictSame(schema.check(obj1).valid, true);
-
-  const obj2 = {
-    struct: {
-      field: 'value',
-    },
-  };
-  test.strictSame(schema.check(obj2).valid, true);
-
-  test.end();
-});
-
-metatests.test('Schema: shorthand', (test) => {
-  const definition = {
-    field1: {
-      n: { type: 'number', default: 100 },
-      c: { type: 'string', shorthand: true },
-    },
-  };
-  const schema = Schema.from(definition);
-
-  const obj1 = { field1: 'value' };
-  test.strictSame(schema.check(obj1).valid, true);
-
-  const obj2 = { field1: 1 };
-  test.strictSame(schema.check(obj2).valid, false);
-
-  const obj3 = { field1: { n: 1, c: 'value' } };
-  test.strictSame(schema.check(obj3).valid, true);
-
-  test.end();
-});
-
-metatests.test('Schema: required shorthand', (test) => {
-  const definition1 = { name: '?string' };
-  const schema1 = Schema.from(definition1);
-
-  const definition2 = { name: { type: '?string' } };
-  const schema2 = Schema.from(definition2);
-
-  const obj1 = { name: 'value' };
-  test.strictSame(schema1.check(obj1).valid, true);
-  test.strictSame(schema2.check(obj1).valid, true);
-
-  const obj2 = {};
-  test.strictSame(schema1.check(obj2).valid, true);
-  test.strictSame(schema2.check(obj2).valid, true);
-
-  const obj3 = { name: 100 };
-  test.strictSame(schema1.check(obj3).valid, false);
-  test.strictSame(schema2.check(obj3).valid, false);
-
-  test.end();
-});
-
-metatests.test('Schema: negative check', (test) => {
-  const definition = {
-    field1: 'string',
-    field2: { type: 'number' },
-    field3: { type: 'string', length: { min: 5, max: 30 } },
-  };
-  const schema = Schema.from(definition);
-
-  const obj1 = {
-    field1: 1,
-    field2: 100,
-    field3: 'value',
-  };
-  test.strictSame(schema.check(obj1).valid, false);
-
-  const obj2 = {
-    field1: 'value',
-    field2: 'value',
-    field3: 'value',
-  };
-  test.strictSame(schema.check(obj2).valid, false);
-
-  const obj3 = {
-    field1: 'value',
-    field2: 100,
-    field3: 'valuevaluevaluevaluevaluevaluevaluevalue',
-  };
-  test.strictSame(schema.check(obj3).valid, false);
-
-  const obj4 = {
-    field1: 'value',
-    field2: 100,
-    field3: 'val',
-  };
-  test.strictSame(schema.check(obj4).valid, false);
-
-  const obj5 = {
-    field1: 'value',
-    field2: 100,
-  };
-  test.strictSame(schema.check(obj5).valid, false);
-  test.end();
-});
-
-metatests.test('Schema: check scalar', (test) => {
-  const def1 = { type: 'string' };
-  const schema1 = Schema.from(def1);
-  test.strictSame(schema1.check('value').valid, true);
-  test.strictSame(schema1.check(1917).valid, false);
-  test.strictSame(schema1.check(true).valid, false);
-  test.strictSame(schema1.check({}).valid, false);
-
-  const def2 = 'string';
-  const schema2 = Schema.from(def2);
-  test.strictSame(schema2.check('value').valid, true);
-  test.strictSame(schema2.check(1917).valid, false);
-  test.strictSame(schema2.check(true).valid, false);
-  test.strictSame(schema2.check({}).valid, false);
-
-  test.end();
-});
-
-metatests.test('Schema: check enum', (test) => {
-  const definition = { field: { enum: ['uno', 'due', 'tre'] } };
-  const schema = Schema.from(definition);
-  test.strictSame(schema.check({ field: 'uno' }).valid, true);
-  test.strictSame(schema.check({ field: 'due' }).valid, true);
-  test.strictSame(schema.check({ field: 'tre' }).valid, true);
-  test.strictSame(schema.check({ field: 'quatro' }).valid, false);
-  test.strictSame(schema.check({ field: 100 }).valid, false);
-  test.strictSame(schema.check({}).valid, false);
-
-  const def1 = { field: { enum: ['uno', 'due', 'tre'], required: false } };
-  const schema1 = Schema.from(def1);
-  test.strictSame(schema1.check({ field: 'uno' }).valid, true);
-
-  const def2 = { field: { enum: ['uno', 'due', 'tre'], required: false } };
-  const schema2 = Schema.from(def2);
-  test.strictSame(schema2.check({ field: 'quatro' }).valid, false);
-
-  const def3 = { field: { enum: ['uno', 'due', 'tre'], required: false } };
-  const schema3 = Schema.from(def3);
-  test.strictSame(schema3.check({}).valid, true);
-
-  const def4 = { field: { array: 'number', required: false } };
-  const schema4 = Schema.from(def4);
-  test.strictSame(schema4.check({ field: [1, 2, 3] }).valid, true);
-
-  const def5 = { field: { array: 'number', required: false } };
-  const schema5 = Schema.from(def5);
-  test.strictSame(schema5.check({ field: ['uno', 2, 3] }).valid, false);
-
-  const def6 = { field: { array: 'number', required: false } };
-  const schema6 = Schema.from(def6);
-  test.strictSame(schema6.check({}).valid, true);
-
-  test.end();
-});
-
-metatests.test('Schema: check enum value', (test) => {
-  const def1 = { enum: ['uno', 'due', 'tre'] };
-  const schema1 = Schema.from(def1);
-  test.strictSame(schema1.check('uno').valid, true);
-  test.strictSame(schema1.check('due').valid, true);
-  test.strictSame(schema1.check('tre').valid, true);
-  test.strictSame(schema1.check('quatro').valid, false);
-  test.strictSame(schema1.check(100).valid, false);
-
-  const def2 = { enum: ['uno', 'due', 'tre'], required: false };
-  const schema2 = Schema.from(def2);
-  test.strictSame(schema2.check('uno').valid, true);
-  test.strictSame(schema2.check('due').valid, true);
-  test.strictSame(schema2.check('tre').valid, true);
-  test.strictSame(schema2.check('quatro').valid, false);
-  test.strictSame(schema2.check(100).valid, false);
-
-  test.end();
-});
-
-metatests.test('Schema: check collections', (test) => {
-  const def1 = {
-    field1: { array: 'number' },
-  };
-  const obj1 = {
-    field1: [1, 2, 3],
-  };
-  const schema1 = Schema.from(def1);
-  test.strictSame(schema1.check(obj1).valid, true);
-
-  const def2 = {
-    field1: { array: 'number' },
-  };
-  const obj2 = {
-    field1: ['uno', 2, 3],
-  };
-  const schema2 = Schema.from(def2);
-  test.strictSame(schema2.check(obj2).valid, false);
-
-  const def3 = {
-    field1: { object: { string: 'string' } },
-  };
-  const obj3 = {
-    field1: { a: 'A', b: 'B' },
-  };
-  const schema3 = Schema.from(def3);
-  test.strictSame(schema3.check(obj3).valid, true);
-
-  const def4 = {
-    field1: { object: { string: 'string' } },
-  };
-  const obj4 = {
-    field1: { a: 1, b: 'B' },
-  };
-  const schema4 = Schema.from(def4);
-  test.strictSame(schema4.check(obj4).valid, false);
-
-  const def5 = {
-    field1: { set: 'number' },
-  };
-  const obj5 = {
-    field1: new Set([1, 2, 3]),
-  };
-  const schema5 = Schema.from(def5);
-  test.strictSame(schema5.check(obj5).valid, true);
-
-  const def6 = {
-    field1: { set: 'number' },
-  };
-  const obj6 = {
-    field1: new Set(['uno', 2, 3]),
-  };
-  const schema6 = Schema.from(def6);
-  test.strictSame(schema6.check(obj6).valid, false);
-
-  const def7 = {
-    field1: { map: { string: 'string' } },
-  };
-  const obj7 = {
-    field1: new Map([
-      ['a', 'A'],
-      ['b', 'B'],
-    ]),
-  };
-  const schema7 = Schema.from(def7);
-  test.strictSame(schema7.check(obj7).valid, true);
-
-  const def8 = {
-    field1: { map: { string: 'string' } },
-  };
-  const obj8 = {
-    field1: new Set([
-      ['a', 1],
-      ['b', 'B'],
-    ]),
-  };
-  const schema8 = Schema.from(def8);
-  test.strictSame(schema8.check(obj8).valid, false);
-
-  test.end();
-});
-
-metatests.test('Schema: check collections value', (test) => {
-  const def1 = { array: 'number' };
-  const obj1 = [1, 2, 3];
-  const schema1 = Schema.from(def1);
-  test.strictSame(schema1.check(obj1).valid, true);
-
-  const def2 = { array: 'number' };
-  const obj2 = ['uno', 2, 3];
-  const schema2 = Schema.from(def2);
-  test.strictSame(schema2.check(obj2).valid, false);
-
-  const def3 = { object: { string: 'string' } };
-  const obj3 = { a: 'A', b: 'B' };
-  const schema3 = Schema.from(def3);
-  test.strictSame(schema3.check(obj3).valid, true);
-
-  const def4 = { object: { string: 'string' } };
-  const obj4 = { a: 1, b: 'B' };
-  const schema4 = Schema.from(def4);
-  test.strictSame(schema4.check(obj4).valid, false);
-
-  const def5 = { set: 'number' };
-  const obj5 = new Set([1, 2, 3]);
-  const schema5 = Schema.from(def5);
-  test.strictSame(schema5.check(obj5).valid, true);
-
-  const def6 = { set: 'number' };
-  const obj6 = new Set(['uno', 2, 3]);
-  const schema6 = Schema.from(def6);
-  test.strictSame(schema6.check(obj6).valid, false);
-
-  const def7 = { map: { string: 'string' } };
-  const obj7 = new Map([
-    ['a', 'A'],
-    ['b', 'B'],
-  ]);
-  const schema7 = Schema.from(def7);
-  test.strictSame(schema7.check(obj7).valid, true);
-
-  const def8 = { map: { string: 'string' } };
-  const obj8 = new Set([
-    ['a', 1],
-    ['b', 'B'],
-  ]);
-  const schema8 = Schema.from(def8);
-  test.strictSame(schema8.check(obj8).valid, false);
-
-  test.end();
-});
-
-metatests.test('Schema: check collections value with long form', (test) => {
-  const def1 = { type: 'array', value: 'number' };
-  const obj1 = [1, 2, 3];
-  const schema1 = Schema.from(def1);
-  test.strictSame(schema1.check(obj1).valid, true);
-
-  const def2 = { type: 'array', value: 'number' };
-  const obj2 = ['uno', 2, 3];
-  const schema2 = Schema.from(def2);
-  test.strictSame(schema2.check(obj2).valid, false);
-
-  const def3 = { type: 'object', key: 'string', value: 'string' };
-  const obj3 = { a: 'A', b: 'B' };
-  const schema3 = Schema.from(def3);
-  test.strictSame(schema3.check(obj3).valid, true);
-
-  const def4 = { type: 'object', key: 'string', value: 'string' };
-  const obj4 = { a: 1, b: 'B' };
-  const schema4 = Schema.from(def4);
-  test.strictSame(schema4.check(obj4).valid, false);
-
-  const def5 = { type: 'set', value: 'number' };
-  const obj5 = new Set([1, 2, 3]);
-  const schema5 = Schema.from(def5);
-  test.strictSame(schema5.check(obj5).valid, true);
-
-  const def6 = { type: 'set', value: 'number' };
-  const obj6 = new Set(['uno', 2, 3]);
-  const schema6 = Schema.from(def6);
-  test.strictSame(schema6.check(obj6).valid, false);
-
-  const def7 = { type: 'map', key: 'string', value: 'string' };
-  const obj7 = new Map([
-    ['a', 'A'],
-    ['b', 'B'],
-  ]);
-  const schema7 = Schema.from(def7);
-  test.strictSame(schema7.check(obj7).valid, true);
-
-  const def8 = { type: 'map', key: 'string', value: 'string' };
-  const obj8 = new Set([
-    ['a', 1],
-    ['b', 'B'],
-  ]);
-  const schema8 = Schema.from(def8);
-  test.strictSame(schema8.check(obj8).valid, false);
-
-  const def9 = { type: 'enum', enum: ['foo', 'bar'] };
-  const schema9 = Schema.from(def9);
-  test.strictSame(schema9.check('foo').valid, true);
-  test.strictSame(schema9.check('bar').valid, true);
-  test.strictSame(schema9.check('baz').valid, false);
-
-  test.end();
-});
-
 metatests.test('Schema: generate ts interface', (test) => {
   const raw = {
-    Company: 'global dictionary',
+    Dictionary: { scope: 'global' },
     name: { type: 'string', unique: true },
     addresses: { many: 'Address' },
   };
 
   const expected = `interface Company {
   companyId: number;
-  name: string;\n}`;
+  name: string;
+  addressesId: number;\n}`;
 
   const schema = new Schema('Company', raw);
   const iface = schema.toInterface();
@@ -620,84 +112,13 @@ metatests.test('Schema: check with namespaces', (test) => {
   test.end();
 });
 
-metatests.test('Schema: multiple optional nested struct', (test) => {
-  const definition = {
-    field: 'string',
-    data: {
-      nfield1: {
-        schema: {
-          text: 'string',
-        },
-        required: false,
-      },
-      nfield2: {
-        schema: {
-          text: 'string',
-          caption: '?string',
-        },
-        required: false,
-      },
-    },
-  };
-  const schema = Schema.from(definition);
-
-  test.strictSame(
-    schema.check({
-      field: 'abc',
-      data: {
-        nfield1: { text: 'abc' },
-      },
-    }),
-    { valid: true, errors: [] }
-  );
-
-  test.strictSame(
-    schema.check({
-      field: 'abc',
-      data: {
-        nfield1: { text: 'abc' },
-        nfield2: { text: 'aaa' },
-      },
-    }),
-    { valid: true, errors: [] }
-  );
-
-  test.strictSame(
-    schema.check({
-      field: 'abc',
-      data: {
-        nfield1: { text: 'abc' },
-        nfield2: { text: 'aaa', caption: 'caption' },
-      },
-    }),
-    { valid: true, errors: [] }
-  );
-
-  test.strictSame(
-    schema.check({
-      field: 'abc',
-      data: {
-        nfield1: {},
-        nfield2: { text: 'aaa', caption: 42 },
-      },
-    }),
-    {
-      valid: false,
-      errors: [
-        `Field "data.nfield1.text" is required`,
-        `Field "data.nfield2.caption" is not of expected type: string`,
-      ],
-    }
-  );
-  test.end();
-});
-
 metatests.test('Schema: validation function', (test) => {
   const definition = {
+    field: '?string',
     validate: test.mustCall((value, path) => {
-      if (value.field) return { valid: true };
+      if (value.field) return true;
       if (value.throw) throw new Error(value.throw);
-      return { valid: false, errors: [`${path}.field is required`] };
+      return `${path}.field is required`;
     }, 3),
   };
   const schema = Schema.from(definition);
@@ -728,12 +149,16 @@ metatests.test('Schema: validation function', (test) => {
 
 metatests.test('Schema: validation function simple return', (test) => {
   const definition = {
+    field: '?string',
     validate: test.mustCall((value) => value.field === '42', 2),
   };
   const schema = Schema.from(definition);
 
   test.strictSame(schema.check({ field: '42' }), { valid: true, errors: [] });
-  test.strictSame(schema.check({ field: '43' }), { valid: false, errors: [] });
+  test.strictSame(schema.check({ field: '43' }), {
+    valid: false,
+    errors: ['Validation error'],
+  });
 
   test.end();
 });
@@ -744,10 +169,11 @@ metatests.test('Schema: nested validation function', (test) => {
     nested: {
       required: false,
       schema: {
+        field: { type: 'string', required: false },
         validate: test.mustCall((value, path) => {
-          if (value.field) return { valid: true };
+          if (value.field) return true;
           if (value.throw) throw new Error(value.throw);
-          return { valid: false, errors: [`${path}.field is required`] };
+          return `${path}.field is required`;
         }, 3),
       },
     },
@@ -767,7 +193,7 @@ metatests.test('Schema: nested validation function', (test) => {
     }),
     {
       valid: false,
-      errors: ['Field "field2" is not expected', 'Field "field" is required'],
+      errors: ['Field "field" is required', 'Field "field2" is not expected'],
     }
   );
 
@@ -824,13 +250,102 @@ metatests.test('Schema: calculated', (test) => {
   test.end();
 });
 
-['enum', 'array', 'set', 'map', 'object'].forEach((type) => {
-  metatests.testSync(`Schema: shorthand ${type} type`, (test) => {
-    test.throws(
-      () => Schema.from({ field1: type }),
-      new Error(
-        `Short string only definition of "field1: '${type}'" is not supported`
-      )
-    );
+metatests.test('Schema: custom function definition', (test) => {
+  const defs = {
+    custom: () => 10,
+  };
+  const schema = Schema.from(defs);
+  test.strictSame(schema.fields.custom(), 10);
+  test.strictSame(schema.check({}).valid, true);
+  test.end();
+});
+
+metatests.test('Schema: reserved fields permitted with Kind', (test) => {
+  const defs = {
+    Struct: {},
+    type: 'string',
+    required: 'string',
+    note: 'string',
+  };
+  const schema = Schema.from(defs);
+  test.strictSame(
+    schema.check({
+      type: 'myType',
+      required: 'never',
+      note: 'this is not vorbidden anymore',
+    }).valid,
+    true
+  );
+  test.strictSame(
+    schema.check({
+      note: 'this is not vorbidden anymore',
+    }).valid,
+    false
+  );
+  test.end();
+});
+
+metatests.test('Schema: custom validate on field', (test) => {
+  const defs1 = {
+    email: {
+      type: 'string',
+      required: true,
+      length: { max: 15 },
+      validate(src) {
+        if (typeof src !== 'string') return false;
+        if (src.length <= 2) {
+          return false;
+        }
+        if (src.indexOf('@') === -1) {
+          return false;
+        }
+        const [, domain] = src.split('@');
+        if (domain.length <= 2) return false;
+        return true;
+      },
+    },
+  };
+
+  const schema1 = Schema.from(defs1);
+  test.strictEqual(schema1.check({ email: 'asd' }).valid, false);
+  test.strictEqual(schema1.check({ email: 'asd@asd.com' }).valid, true);
+  test.strictEqual(
+    schema1.check({ email: 'asdasdasdasdasdasd@asd.com' }).valid,
+    false
+  );
+  const defs2 = {
+    type: 'number',
+    validate(num) {
+      if (num !== 10) throw new Error('Not a ten');
+    },
+  };
+  const defs3 = {
+    type: 'number',
+    validate(num) {
+      if (num !== 10) return 'Not a ten';
+    },
+  };
+  const defs4 = {
+    type: 'number',
+    validate(num) {
+      if (num !== 10) return ['Not', 'a', 'ten'];
+    },
+  };
+  const schema2 = Schema.from(defs2);
+  const schema3 = Schema.from(defs3);
+  const schema4 = Schema.from(defs4);
+  test.strictSame(schema2.check(12), { valid: false, errors: ['Not a ten'] });
+  test.strictSame(schema3.check(12), { valid: false, errors: ['Not a ten'] });
+  test.strictSame(schema4.check(12), {
+    valid: false,
+    errors: ['Not', 'a', 'ten'],
   });
+  test.strictSame(schema2.check(10).valid, true);
+  test.strictSame(schema3.check(10).valid, true);
+  test.strictSame(schema4.check(10).valid, true);
+  const defs5 = { num: { type: 'number', validate: (num) => num === 10 } };
+  const schema5 = Schema.from(defs5);
+  test.strictSame(schema5.check({ num: 12 }).valid, false);
+  test.strictSame(schema5.check({ num: 10 }).valid, true);
+  test.end();
 });

--- a/test/schemas/.types.js
+++ b/test/schemas/.types.js
@@ -1,3 +1,26 @@
 ({
-  ip: 'inet',
+  ip: {
+    js: 'string',
+    pg: 'inet',
+  },
+  decimal: {
+    pg: 'decimal',
+    kind: 'scalar',
+    rules: ['length'],
+    symbols: '1234567890e.',
+    validate(src, path) {
+      if (typeof src !== 'string') {
+        return `Field "${path}" not a decimal 1`;
+      }
+      const arr = src.split('.');
+      if (arr.length !== 2) return `Field "${path}" not a decimal 2`;
+      const [a, b] = arr;
+      const chars = new Set([...a, ...b]);
+      for (const char of chars) {
+        if (!this.symbols.includes(char))
+          return `Field "${path}" not a decimal 3`;
+      }
+    },
+    format() {},
+  },
 });

--- a/test/schemas/.types.js
+++ b/test/schemas/.types.js
@@ -8,7 +8,7 @@
     kind: 'scalar',
     rules: ['length'],
     symbols: '1234567890e.',
-    validate(src, path) {
+    checkType(src, path) {
       if (typeof src !== 'string') {
         return `Field "${path}" not a decimal 1`;
       }
@@ -21,6 +21,6 @@
           return `Field "${path}" not a decimal 3`;
       }
     },
-    format() {},
+    construct() {},
   },
 });

--- a/test/schemas/Aaa.js
+++ b/test/schemas/Aaa.js
@@ -1,0 +1,6 @@
+({
+  Projection: {
+    schema: 'Account',
+    fields: ['login', 'password'],
+  },
+});

--- a/test/structs.js
+++ b/test/structs.js
@@ -1,0 +1,234 @@
+'use strict';
+
+const metatests = require('metatests');
+const { Schema } = require('../metaschema');
+
+metatests.test('Structs: nested schema', (test) => {
+  const definition = {
+    field1: 'string',
+    field2: {
+      schema: {
+        subfield1: 'number',
+        subfield2: 'string',
+      },
+    },
+  };
+  const obj = {
+    field1: 'value',
+    field2: {
+      subfield1: 500,
+      subfield2: 'value',
+    },
+  };
+  const schema = Schema.from(definition);
+  test.strictSame(schema.check(obj).valid, true);
+  test.end();
+});
+
+metatests.test('Structs: nested schema, lost field', (test) => {
+  const schema = Schema.from({
+    field1: 'string',
+    field2: {
+      subfield1: 'number',
+    },
+    field3: 'string',
+  });
+
+  const obj = {
+    field1: 'value',
+    field2: {},
+  };
+  test.strictSame(schema.check(obj), {
+    valid: false,
+    errors: [
+      'Field "field2.subfield1" is required',
+      'Field "field3" is required',
+    ],
+  });
+
+  test.end();
+});
+
+metatests.test('Structs: optional nested struct', (test) => {
+  const definition = {
+    struct: {
+      required: false,
+      schema: {
+        field: 'string',
+      },
+    },
+  };
+  const schema = Schema.from(definition);
+
+  const obj1 = {};
+  test.strictSame(schema.check(obj1).valid, true);
+
+  const obj2 = {
+    struct: {
+      field: 'value',
+    },
+  };
+  test.strictSame(schema.check(obj2).valid, true);
+
+  test.end();
+});
+
+metatests.test('Structs: optional nested struct base object', (test) => {
+  const definition = {
+    text: 'string',
+    struct: {
+      required: false,
+      schema: {
+        field: 'string',
+      },
+    },
+  };
+  const schema = Schema.from(definition);
+
+  const obj1 = { text: 'abc' };
+  test.strictSame(schema.check(obj1), { valid: true, errors: [] });
+
+  const obj2 = {
+    text: 'abc',
+    struct: {
+      field: 'value',
+    },
+  };
+  test.strictSame(schema.check(obj2), { valid: true, errors: [] });
+
+  test.end();
+});
+
+metatests.test('Structs: shorthand for optional nested struct', (test) => {
+  const definition = {
+    'struct?': {
+      field: 'string',
+    },
+  };
+  const schema = Schema.from(definition);
+
+  const obj1 = {};
+  test.strictSame(schema.check(obj1).valid, true);
+
+  const obj2 = {
+    struct: {
+      field: 'value',
+    },
+  };
+  test.strictSame(schema.check(obj2).valid, true);
+
+  test.end();
+});
+
+metatests.test('Structs: multiple optional nested struct', (test) => {
+  const definition = {
+    field: 'string',
+    data: {
+      nfield1: {
+        schema: {
+          text: 'string',
+        },
+        required: true,
+      },
+      nfield2: {
+        schema: {
+          text: 'string',
+          caption: '?string',
+        },
+        required: false,
+      },
+    },
+  };
+  const schema = Schema.from(definition);
+
+  test.strictSame(
+    schema.check({
+      field: 'abc',
+      data: {
+        nfield1: { text: 'abc' },
+      },
+    }),
+    { valid: true, errors: [] }
+  );
+
+  test.strictSame(
+    schema.check({
+      field: 'abc',
+      data: {
+        nfield1: { text: 'abc' },
+        nfield2: { text: 'aaa' },
+      },
+    }),
+    { valid: true, errors: [] }
+  );
+
+  test.strictSame(
+    schema.check({
+      field: 'abc',
+      data: {
+        nfield1: { text: 'abc' },
+        nfield2: { text: 'aaa', caption: 'caption' },
+      },
+    }),
+    { valid: true, errors: [] }
+  );
+
+  test.strictSame(
+    schema.check({
+      field: 'abc',
+      data: {
+        nfield1: {},
+        nfield2: { text: 'aaa', caption: 42 },
+      },
+    }),
+    {
+      valid: false,
+      errors: [
+        `Field "data.nfield1.text" is required`,
+        `Field "data.nfield2.caption" is not of expected type: string`,
+      ],
+    }
+  );
+  test.end();
+});
+
+metatests.test('Structs: nested schemas with Schema instances', (test) => {
+  const def = {
+    name: {
+      type: 'schema',
+      schema: new Schema('', {
+        first: { type: 'string' },
+        last: { type: 'string' },
+        third: { type: 'string' },
+      }),
+    },
+    age: { type: 'number' },
+    levelOne: {
+      type: 'schema',
+      schema: new Schema('', {
+        levelTwo: {
+          type: 'schema',
+          schema: new Schema('', {
+            levelThree: { type: 'enum', enum: [1, 2, 3] },
+          }),
+        },
+      }),
+    },
+  };
+  const obj = {
+    name: {
+      first: 'Andrew',
+      last: 'John',
+      third: 'John',
+    },
+    age: 5,
+    levelOne: {
+      levelTwo: {
+        levelThree: 2,
+      },
+    },
+  };
+  const schema = new Schema('', def);
+  test.strictSame(schema.check(obj).valid, true);
+  test.end();
+});

--- a/test/structs.js
+++ b/test/structs.js
@@ -185,7 +185,7 @@ metatests.test('Structs: multiple optional nested struct', (test) => {
       valid: false,
       errors: [
         `Field "data.nfield1.text" is required`,
-        `Field "data.nfield2.caption" is not of expected type: string`,
+        `Field "data.nfield2.caption" not of expected type: string`,
       ],
     }
   );

--- a/test/types.js
+++ b/test/types.js
@@ -1,0 +1,46 @@
+'use strict';
+const metatests = require('metatests');
+const { prepareTypes, DEFAULT } = require('../lib/types.js');
+
+const types = {
+  string: 'varchar',
+  number: 'integer',
+  datetime: { js: 'string', pg: 'timestamp with time zone' },
+  text: { js: 'string', pg: 'text' },
+  json: { js: 'schema', pg: 'jsonb' },
+  decimal: {
+    pg: 'decimal',
+    kind: 'scalar',
+    rules: ['length'],
+    symbols: '1234567890e.',
+    validate(src, path) {
+      if (typeof src !== 'string') {
+        return `Field "${path}" not a decimal 1`;
+      }
+      const arr = src.split('.');
+      if (arr.length !== 2) return `Field "${path}" not a decimal 2`;
+      const [a, b] = arr;
+      const chars = new Set([...a, ...b]);
+      for (const char of chars) {
+        if (!this.symbols.includes(char)) {
+          return `Field "${path}" not a decimal 3`;
+        }
+      }
+    },
+    format() {},
+  },
+};
+
+metatests.test('Types: prepareTypes', (test) => {
+  const tps = prepareTypes(types);
+  const { datetime, text, json, decimal } = tps;
+  test.strictEqual(datetime.prototype.pg, types.datetime.pg);
+  test.strictEqual(text.prototype.pg, types.text.pg);
+  test.strictEqual(json.prototype.pg, types.json.pg);
+  test.strictEqual(decimal.prototype.pg, types.decimal.pg);
+  const { string, number } = tps;
+  test.strictEqual(new string().pg, types.string);
+  test.strictEqual(new number().pg, types.number);
+  test.strictEqual(DEFAULT.string.prototype.pg, undefined);
+  test.end();
+});

--- a/test/types.js
+++ b/test/types.js
@@ -13,7 +13,7 @@ const types = {
     kind: 'scalar',
     rules: ['length'],
     symbols: '1234567890e.',
-    validate(src, path) {
+    checkType(src, path) {
       if (typeof src !== 'string') {
         return `Field "${path}" not a decimal 1`;
       }
@@ -27,7 +27,7 @@ const types = {
         }
       }
     },
-    format() {},
+    construct() {},
   },
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings

Need help:
 - or ideas for Preprocessor - improve code quality
 - overall - better naming
 - Model change reorder to remove hardcoded projection

Non breaking:
 - elegant syntax/format for custom types and internal types
 - custom types support
 - preprocessor to reduce Schema preprocess complexity
 - any kind of nested arrays, array of references https://github.com/metarhia/metaschema/issues/378
 - nested schemas with Schema instances support
 - any level of complex nested types support
 - custom validate for field
 - changed validate for schema, simplified for user
 - all user's validate functions support 4 types of syntax: boolean return, throw Error, error message as string return and array of error messages
 - reserved words permitted in schema if kind provided
 - function fields stored in schema
 - shorthand required key for collections support `{ 'array?': 'string' }`
 - many relation now checks in runtime
 - model now loads projections at the end, to fix bug
 - schema kinds moved to separate file and kinds now have logic to remove hardcoded projection from Schema
 - ts interfaces from schema now have relation ids as well
 - deps update metautil
 - nested object support https://github.com/metarhia/metaschema/issues/395
 - syntax for validate function changed

Breaking:
 - Model no more require metavm for browser compatibility: need `impress` update
 - loadModel moved to loader: need `impress` update
 - Model no more writes d.ts file to disk moved to loader as well: need `metasql` update
 - syntax for pg types changed a bit, no more not-working types: need `metasql` update
 - not supporting custom Schema kinds: need to not use custom kinds in schemas folder: `application/schemas/<YourSchema.js>`
