### PR TITLE
Now type is responsible for handling it's required rule

### DIFF
--- a/lib/prototypes/abstract.js
+++ b/lib/prototypes/abstract.js
@@ -7,6 +7,7 @@ const AbstractType = {
   checks: {},
   check(value, path, root) {
     const field = path || root.name;
+    if (!this.required && value === undefined) return [];
     try {
       const typeErr = prettifyErr(this.checkType(value, path, root), field);
       if (typeErr) return typeErr;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -173,8 +173,8 @@ class Schema {
         errors.push(`Field "${name}" is not expected`);
         continue;
       }
+      if (!isType(type)) continue;
       const nestedPath = path ? `${path}.${name}` : name;
-      if (!type.required && value === undefined) continue;
       if (type.required && !keys.includes(name)) {
         errors.push(`Field "${nestedPath}" is required`);
         continue;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)

Small fix to improve logic of an implementation. There is no bug, just small improvement to reduce amount of code needed to write custom or new types by 1 line and prevent boilerplate from appearing
