### PR TITLE
Fix issue - added keeping of custom types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -72,10 +72,9 @@ const checkCustomType = (proto) => {
 };
 
 const typeFactory = (customTypes) => {
-  const types = { ...TYPES };
   for (const [name, value] of Object.entries(customTypes)) {
     const { js, metadata, ...rest } = value;
-    let Type = types[name];
+    let Type = TYPES[name];
     if (Type) {
       updateTypeMetadata(Type, metadata);
       continue;
@@ -84,9 +83,9 @@ const typeFactory = (customTypes) => {
     checkCustomType(proto);
     Type = createType(name, proto);
     updateTypeMetadata(Type, metadata);
-    types[name] = Type;
+    TYPES[name] = Type;
   }
-  return types;
+  return TYPES;
 };
 
 module.exports = { typeFactory, TYPES };


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->
This pull request fixes an issue that occurs when adding (updating) new schemas with custom types while the application is running. The fix stores the initialized custom types in the TYPES object, and when adding (updating) schemas, the custom types will be available.

Fixes #472
- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
