### PR TITLE
Add metacom-build as es bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .DS_Store
+metaschema.mjs

--- a/build.json
+++ b/build.json
@@ -1,0 +1,20 @@
+{
+  "order": [
+    "kinds.js",
+    "metadata.js",
+    "util.js",
+    "struct.js",
+    "preprocessor.js",
+    "prototypes/abstract.js",
+    "prototypes/scalars.js",
+    "prototypes/collections.js",
+    "prototypes/reference.js",
+    "prototypes/schema.js",
+    "prototypes/tuple.js",
+    "prototypes/json.js",
+    "types.js",
+    "schema.js",
+    "model.js"
+  ],
+  "require": ["metautil"]
+}

--- a/dist.js
+++ b/dist.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const schema = require('./lib/schema.js');
-const model = require('./lib/model.js');
-const { constants } = require('./lib/kinds.js');
-
-module.exports = { ...schema, ...model, ...constants };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,4 +10,13 @@ module.exports = [
       strict: 'off',
     },
   },
+  {
+    files: ['metaschema.mjs'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: {
+        crypto: 'readonly',
+      },
+    },
+  },
 ];

--- a/lib/kinds.js
+++ b/lib/kinds.js
@@ -12,7 +12,7 @@ const SCOPE = ['application', 'global', 'local'];
 const STORE = ['persistent', 'memory'];
 const ALLOW = ['write', 'append', 'read'];
 
-const projection = (kind, meta, root) => {
+const getProjection = (kind, meta, root) => {
   const { scope = 'local', store = 'memory', allow = 'write' } = meta;
   const metadata = { ...meta, kind, scope, store, allow };
   const { schema, fields } = meta;
@@ -40,13 +40,15 @@ const kindMemory = (kind, meta) => {
 };
 
 const getKindMetadata = (kind, meta = {}, root) => {
-  if (kind === 'projection') return projection(kind, meta, root);
+  if (kind === 'projection') return getProjection(kind, meta, root);
   if (KIND_MEMORY.includes(kind)) return kindMemory(kind, meta);
   if (KIND_STORED.includes(kind)) return kindStored(kind, meta, root);
   return kindMemory(kind, meta);
 };
 
-module.exports = {
+const kinds = {
   getKindMetadata,
   constants: { KIND, KIND_STORED, KIND_MEMORY, SCOPE, STORE, ALLOW },
 };
+
+module.exports = kinds;

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const metautil = require('metautil');
-const { isFirstUpper, toLowerCamel, firstKey } = metautil;
+const { isFirstUpper, toLowerCamel, firstKey } = require('metautil');
 const { formatters } = require('./util.js');
 
 const PARSERS = {

--- a/lib/prototypes/collections.js
+++ b/lib/prototypes/collections.js
@@ -95,4 +95,6 @@ const set = {
   },
 };
 
-module.exports = { object, map, array, set };
+const collections = { object, map, array, set };
+
+module.exports = collections;

--- a/lib/prototypes/scalars.js
+++ b/lib/prototypes/scalars.js
@@ -25,11 +25,12 @@ const enumerable = {
     return `Field "${path}" value is not of enum: ${this.enum.join(', ')}`;
   },
 };
-
-module.exports = {
+const scalars = {
   string: { scalar: 'string', rules: ['length'], ...scalar },
   number: { scalar: 'number', rules: ['length'], ...scalar },
   bigint: { scalar: 'bigint', rules: ['length'], ...scalar },
   boolean: { scalar: 'boolean', ...scalar },
   enum: enumerable,
 };
+
+module.exports = scalars;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^24.4.0",
         "eslint": "^9.35.0",
         "eslint-config-metarhia": "^9.1.3",
+        "metarhia-build": "^0.0.0",
         "prettier": "^3.6.2",
         "typescript": "^5.9.2"
       },
@@ -263,6 +264,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -451,6 +453,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -532,6 +535,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -930,6 +934,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/metarhia-build": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/metarhia-build/-/metarhia-build-0.0.0.tgz",
+      "integrity": "sha512-alSOcmmXgeGnyvcxgqyd46zvrYe5jfqqdQl2DMY+ngnLlm9WKJFPPt6cOo+BA80+Z/lPj1XAF0W1edk/Iamg4Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "metarhia-build": "metarhia-build.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/tshemsedinov"
+      }
+    },
     "node_modules/metautil": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/metautil/-/metautil-5.4.0.tgz",
@@ -1082,6 +1103,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "main": "metaschema.js",
   "browser": {
-    "./metaschema.js": "./dist.js"
+    "./metaschema.js": "./metaschema.mjs"
   },
   "types": "metaschema.d.ts",
   "files": [
@@ -38,6 +38,7 @@
   ],
   "readmeFilename": "README.md",
   "scripts": {
+    "build": "metarhia-build",
     "test": "npm run lint && npm run types && node --test",
     "types": "tsc -p tsconfig.json",
     "lint": "eslint . && prettier -c \"**/*.js\" \"**/*.json\" \"**/*.md\" \"**/*.ts\"",
@@ -54,6 +55,7 @@
     "@types/node": "^24.4.0",
     "eslint": "^9.35.0",
     "eslint-config-metarhia": "^9.1.3",
+    "metarhia-build": "^0.0.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2"
   }


### PR DESCRIPTION
- add files and required metautil in order for es bundle
- fixed some module.exports to not break bundled file with missing references

https://github.com/metarhia/metautil/issues/311

[builder PR](https://github.com/metarhia/metarhia-build/pull/2)

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
